### PR TITLE
vc-svn backend needs some love too!

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -123,6 +123,7 @@
 (defmacro diff-hl-with-diff-switches (body)
   `(let ((vc-git-diff-switches nil)
          (vc-hg-diff-switches nil)
+         (vc-svn-diff-switches nil)
          (vc-diff-switches '("-U0"))
          (vc-disable-async-diff t))
      ,body))


### PR DESCRIPTION
Added necessary switches reset for vc-svn backend. Probably need to add the same for, like, everything else as well? Otherwise context won't be zero.

PS: А ещё она люто глючит на 24.2 под osx - рисуются какие-то ошмётки зелёных полосок не там где надо и без фона. Но тут мне уже лень копать, я поставил претест 24.3 и всё стало хорошо. И вообще - спасибо, полезная вещь.
