### PR TITLE
Move diff-hl-margin-side after diff-hl-margin-mode definition

### DIFF
--- a/diff-hl-margin.el
+++ b/diff-hl-margin.el
@@ -44,16 +44,6 @@
   "Highlight buffer changes on margin"
   :group 'diff-hl)
 
-(defcustom diff-hl-margin-side 'left
-  "Which margin to use for indicators."
-  :type '(choice (const left)
-                 (const right))
-  :set (lambda (var value)
-         (let ((on diff-hl-margin-mode))
-           (when on (diff-hl-margin-mode -1))
-           (set-default var value)
-           (when on (diff-hl-margin-mode 1)))))
-
 ;;;###autoload
 (define-minor-mode diff-hl-margin-mode
   "Toggle displaying `diff-hl-mode' highlights on the margin."
@@ -95,6 +85,16 @@ You probably shouldn't use this function directly."
       (set width-var 0)))
   (dolist (win (get-buffer-window-list))
     (set-window-buffer win (current-buffer))))
+
+(defcustom diff-hl-margin-side 'left
+  "Which margin to use for indicators."
+  :type '(choice (const left)
+                 (const right))
+  :set (lambda (var value)
+         (let ((on diff-hl-margin-mode))
+           (when on (diff-hl-margin-mode -1))
+           (set-default var value)
+           (when on (diff-hl-margin-mode 1)))))
 
 (defun diff-hl-margin-minor-mode-off ()
   (diff-hl-margin-minor-mode -1))


### PR DESCRIPTION
Using Emacs 24.4.1 (in Debian), I cloned this repo into my ~/.emacs.d and added the following to my init.el:

```elisp
(add-to-list 'load-path (locate-user-emacs-file "diff-hl"))
(require 'diff-hl)
(global-diff-hl-mode)
(unless (window-system)
    (require 'diff-hl-margin)
    (diff-hl-margin-mode))
```
This caused the below error when starting Emacs

> Warning (initialization): An error occurred while loading `/home/mccoyj1/.emacs.d/init.el':
>
> Symbol's value as variable is void: diff-hl-margin-mode

Moving the use of `diff-hl-margin-mode` after its definition fixes the problem for me.