### PR TITLE
silence byte-compiler

### DIFF
--- a/diff-hl-margin.el
+++ b/diff-hl-margin.el
@@ -38,6 +38,8 @@
 (require 'diff-hl)
 (require 'diff-hl-dired)
 
+(defvar diff-hl-margin-side)
+
 (defvar diff-hl-margin-old-highlight-function nil)
 
 (defgroup diff-hl-margin nil

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -59,7 +59,8 @@
   (require 'cl-lib)
   (require 'vc-git)
   (require 'vc-hg)
-  (require 'face-remap))
+  (require 'face-remap)
+  (declare-function smartrep-define-key 'smartrep))
 
 (defgroup diff-hl nil
   "VC diff highlighting on the side of a window"


### PR DESCRIPTION
Declaring `diff-hl-margin-side` silences the byte-compiler, but you might also want to check whether you have to define the options more carefully (possibly using `:set-after`).

Also you might wanna change the newline encoding in `diff-hl.el`.