### PR TITLE
Declare variable vc-disable-async-diff

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -207,6 +207,7 @@
     (t (intern (format "diff-hl-bmp-%s" type)))))
 
 (defvar vc-svn-diff-switches)
+(defvar vc-disable-async-diff)
 
 (defmacro diff-hl-with-diff-switches (body)
   `(let ((vc-git-diff-switches nil)

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -437,13 +437,13 @@ in the source file, or the last line of the hunk above it."
   (interactive)
   (diff-hl-next-hunk t))
 
-(define-prefix-command 'diff-hl-command-map)
-
-(let ((map diff-hl-command-map))
-  (define-key map "n" 'diff-hl-revert-hunk)
-  (define-key map "[" 'diff-hl-previous-hunk)
-  (define-key map "]" 'diff-hl-next-hunk)
-  map)
+(defvar diff-hl-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "n" 'diff-hl-revert-hunk)
+    (define-key map "[" 'diff-hl-previous-hunk)
+    (define-key map "]" 'diff-hl-next-hunk)
+    map))
+(fset 'diff-hl-command-map diff-hl-command-map)
 
 ;;;###autoload
 (define-minor-mode diff-hl-mode


### PR DESCRIPTION
This tells the byte-compiler that it is a dynamically bound variable,
preventing the byte-compiler from thinking it is an unused lexically
bound variable.