### PR TITLE
[WIP] Allow diffing on-the-fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The package also contains auxiliary modes:
 * `diff-hl-margin-mode` changes the highlighting function to
   use the margin instead of the fringe.
 * `diff-hl-amend-mode` shifts the reference revision back by one.
+* `diff-hl-flydiff-mode` enables diffing unsaved changes
 
 Check out the Commentary section in each respective file for the usage
 instructions.
@@ -45,11 +46,6 @@ Emacs 24+. On OS X, Emacs 24.3 or higher is recommended.
 
 Notes
 =====
-
-* Since it uses the corresponding VC diff command, it's only accurate when the
-  buffer is in saved state. Highlighting changes "on the fly" might be better,
-  maybe we can do something similar to `highlight-markup-buffers` with a hidden
-  buffer containing the unmodified copy.
 
 * We conflict with other modes when they put indicators on the fringe,
   such as [Flycheck](https://github.com/flycheck/flycheck). This is

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -66,6 +66,11 @@
     (advice-add 'vc-git-mode-line-string :override
       #'diff-hl-flydiff/vc-git-mode-line-string)))
 
+(defun diff-hl-flydiff/working-revision (file)
+  "Like vc-working-revision, but always up-to-date"
+  (vc-file-setprop file 'vc-working-revision
+    (vc-call-backend (vc-backend file) 'working-revision file)))
+
 (defun diff-hl-flydiff-make-temp-file-name (file rev &optional manual)
   "Return a backup file name for REV or the current version of FILE.
 If MANUAL is non-nil it means that a name for backups created by
@@ -114,13 +119,10 @@ This requires the external program `diff' to be in your `exec-path'."
               (if (file-directory-p "/dev/shm/")
                 "/dev/shm/"
                 temporary-file-directory))
-            (rev (diff-hl-flydiff-create-revision
-                   file
-                   (vc-working-revision file
-                     (vc-responsible-backend file)))))
+            (rev (diff-hl-flydiff-create-revision file
+                   (diff-hl-flydiff/working-revision file))))
       (diff-no-select rev (current-buffer) "-U 0" 'noasync
         (get-buffer-create " *diff-hl-diff*")))))
-
 
 (defun diff-hl-flydiff/update (old-fun &optional auto)
   (unless (and auto

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -1,4 +1,4 @@
-;; Copyright (C) 2012-2013  Free Software Foundation, Inc.
+;; Copyright (C) 2015 Free Software Foundation, Inc.
 
 ;; Author:   Jonathan Hayase <PythonNut@gmail.com>
 ;; URL:      https://github.com/dgutov/diff-hl

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -132,14 +132,7 @@ This requires the external program `diff' to be in your `exec-path'."
     (funcall old-fun)))
 
 (defun diff-hl-flydiff/modified-p (state)
-  (or
-    (buffer-modified-p)
-    (eq state 'edited)
-    (and (eq state 'up-to-date)
-      ;; VC state is stale in after-revert-hook.
-      (or revert-buffer-in-progress-p
-        ;; Diffing against an older revision.
-        diff-hl-reference-revision))))
+  (buffer-modified-p))
 
 (defun diff-hl-flydiff/update-modified-tick (&rest args)
   (setq diff-hl-flydiff-modified-tick (buffer-modified-tick)))
@@ -154,7 +147,7 @@ This requires the external program `diff' to be in your `exec-path'."
       (advice-add 'diff-hl-update :around #'diff-hl-flydiff/update)
       (advice-add 'diff-hl-overlay-modified :override #'ignore)
 
-      (advice-add 'diff-hl-modified-p :override
+      (advice-add 'diff-hl-modified-p :before-until
         #'diff-hl-flydiff/modified-p)
       (advice-add 'diff-hl-changes-buffer :override
         #'diff-hl-flydiff-buffer-with-head)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -1,0 +1,200 @@
+;; Copyright (C) 2012-2013  Free Software Foundation, Inc.
+
+;; Author:   Jonathan Hayase <PythonNut@gmail.com>
+;; URL:      https://github.com/dgutov/diff-hl
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'diff-hl)
+
+(defvar diff-hl-flydiff-modified-tick 0)
+(defvar diff-hl-flydiff-timer)
+(make-variable-buffer-local 'diff-hl-flydiff-modified-tick)
+
+;; Polyfill concrete revisions for vc-git-working-revision in Emacs 24.4, 24.5
+(when (version<= emacs-version "24.5")
+  (with-eval-after-load 'vc-git
+    (defun vc-git--symbolic-ref (file)
+      (or
+        (vc-file-getprop file 'vc-git-symbolic-ref)
+        (let* (process-file-side-effects
+                (str (vc-git--run-command-string nil "symbolic-ref" "HEAD")))
+          (vc-file-setprop file 'vc-git-symbolic-ref
+            (if str
+              (if (string-match "^\\(refs/heads/\\)?\\(.+\\)$" str)
+                (match-string 2 str)
+                str))))))
+
+    (defun diff-hl-flydiff/vc-git-working-revision (_file)
+      "Git-specific version of `vc-working-revision'."
+      (let (process-file-side-effects)
+        (vc-git--rev-parse "HEAD")))
+
+    (defun diff-hl-flydiff/vc-git-mode-line-string (file)
+      "Return a string for `vc-mode-line' to put in the mode line for FILE."
+      (let* ((rev (vc-working-revision file))
+              (disp-rev (or (vc-git--symbolic-ref file)
+                          (substring rev 0 7)))
+              (def-ml (vc-default-mode-line-string 'Git file))
+              (help-echo (get-text-property 0 'help-echo def-ml)))
+        (propertize (replace-regexp-in-string (concat rev "\\'") disp-rev def-ml t t)
+          'help-echo (concat help-echo "\nCurrent revision: " rev))))
+
+    (advice-add 'vc-git-working-revision :override
+      #'diff-hl-flydiff/vc-git-working-revision)
+    (advice-add 'vc-git-mode-line-string :override
+      #'diff-hl-flydiff/vc-git-mode-line-string)))
+
+(defun diff-hl-flydiff-make-temp-file-name (file rev &optional manual)
+  "Return a backup file name for REV or the current version of FILE.
+If MANUAL is non-nil it means that a name for backups created by
+the user should be returned."
+  (let* ((auto-save-file-name-transforms
+           `((".*" ,temporary-file-directory t))))
+    (expand-file-name
+      (concat (make-auto-save-file-name)
+        ".~" (subst-char-in-string
+               ?/ ?_ rev)
+        (unless manual ".") "~")
+      temporary-file-directory)))
+
+(defun diff-hl-flydiff-create-revision (file revision)
+  "Read REVISION of FILE into a buffer and return the buffer."
+  (let ((automatic-backup (diff-hl-flydiff-make-temp-file-name file revision))
+         (filebuf (get-file-buffer file))
+         (filename (diff-hl-flydiff-make-temp-file-name file revision 'manual)))
+    (unless (file-exists-p filename)
+      (if (file-exists-p automatic-backup)
+        (rename-file automatic-backup filename nil)
+        (with-current-buffer filebuf
+          (let ((failed t)
+                 (coding-system-for-read 'no-conversion)
+                 (coding-system-for-write 'no-conversion))
+            (unwind-protect
+              (with-temp-file filename
+                (let ((outbuf (current-buffer)))
+                  ;; Change buffer to get local value of
+                  ;; vc-checkout-switches.
+                  (with-current-buffer filebuf
+                    (vc-call find-revision file revision outbuf))))
+              (setq failed nil)
+              (when (and failed (file-exists-p filename))
+                (delete-file filename)))))))
+    filename))
+
+(defun diff-hl-flydiff-buffer-with-head ()
+  "View the differences between BUFFER and its associated file.
+This requires the external program `diff' to be in your `exec-path'."
+  (interactive)
+  (vc-ensure-vc-buffer)
+  (with-current-buffer (get-buffer (current-buffer))
+    (let ((rev (diff-hl-flydiff-create-revision
+                 buffer-file-name
+                 (vc-working-revision buffer-file-name
+                   (vc-responsible-backend buffer-file-name))))
+           (temporary-file-directory
+             (if (file-directory-p "/dev/shm/")
+               "/dev/shm/"
+               temporary-file-directory)))
+      (diff-no-select rev (current-buffer) "-U 0" 'noasync
+        (get-buffer-create " *diff-hl-diff*")))))
+
+
+(defun diff-hl-flydiff/update (old-fun &optional auto)
+  (unless (and auto
+            (or
+              (= diff-hl-flydiff-modified-tick (buffer-modified-tick))
+              (file-remote-p default-directory)
+              (not (buffer-modified-p))))
+    (funcall old-fun)))
+
+(defun diff-hl-flydiff/changes (&rest args)
+  (let* ((file buffer-file-name)
+          (backend (vc-backend file)))
+    (when backend
+      (let ((state (vc-state file backend)))
+        (cond
+          ((or
+             (buffer-modified-p)
+             (eq state 'edited)
+             (and (eq state 'up-to-date)
+               ;; VC state is stale in after-revert-hook.
+               (or revert-buffer-in-progress-p
+                 ;; Diffing against an older revision.
+                 diff-hl-reference-revision)))
+            (let (diff-auto-refine-mode res)
+              (with-current-buffer (diff-hl-flydiff-buffer-with-head)
+                (goto-char (point-min))
+                (unless (eobp)
+                  (ignore-errors
+                    (diff-beginning-of-hunk t))
+                  (while (looking-at diff-hunk-header-re-unified)
+                    (let ((line (string-to-number (match-string 3)))
+                           (len (let ((m (match-string 4)))
+                                  (if m (string-to-number m) 1)))
+                           (beg (point)))
+                      (diff-end-of-hunk)
+                      (let* ((inserts (diff-count-matches "^\\+" beg (point)))
+                              (deletes (diff-count-matches "^-" beg (point)))
+                              (type (cond ((zerop deletes) 'insert)
+                                      ((zerop inserts) 'delete)
+                                      (t 'change))))
+                        (when (eq type 'delete)
+                          (setq len 1)
+                          (cl-incf line))
+                        (push (list line len type) res))))))
+              (setq diff-hl-flydiff-modified-tick (buffer-modified-tick))
+              (nreverse res)))
+          ((eq state 'added)
+            `((1 ,(line-number-at-pos (point-max)) insert)))
+          ((eq state 'removed)
+            `((1 ,(line-number-at-pos (point-max)) delete))))))))
+
+(defun diff-hl-flydiff/overlay-modified (&rest args))
+
+;;;###autoload
+(define-minor-mode diff-hl-flydiff-mode
+  "Highlight diffs on-the-fly"
+  :lighter ""
+  :global t
+  (if diff-hl-flydiff-mode
+    (progn
+      (require 'nadvice)
+      (advice-add 'diff-hl-update :around
+        #'diff-hl-flydiff/update)
+      (advice-add 'diff-hl-changes :override
+        #'diff-hl-flydiff/changes)
+      (advice-add 'diff-hl-overlay-modified :override
+        #'diff-hl-flydiff/overlay-modified)
+
+      (remove-hook 'after-change-functions #'diff-hl-edit t)
+      (setq diff-hl-flydiff-timer
+        (run-with-idle-timer 0.3 t #'diff-hl-update t)))
+
+    (advice-remove 'diff-hl-update #'diff-hl-flydiff/update)
+    (advice-remove 'diff-hl-changes #'diff-hl-flydiff/changes)
+    (advice-remove 'diff-hl-overlay-modified
+      #'diff-hl-flydiff/overlay-modified)
+
+    (cancel-timer diff-hl-flydiff-timer)
+    (when diff-hl-mode
+      (add-hook 'after-change-functions 'diff-hl-edit nil t))))
+
+(provide 'diff-hl-flydiff)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'diff-hl)
+(require 'nadvice)
 
 (defvar diff-hl-flydiff-modified-tick 0)
 (defvar diff-hl-flydiff-timer)
@@ -177,7 +178,6 @@ This requires the external program `diff' to be in your `exec-path'."
   :global t
   (if diff-hl-flydiff-mode
     (progn
-      (require 'nadvice)
       (advice-add 'diff-hl-update :around #'diff-hl-flydiff/update)
       (advice-add 'diff-hl-changes :override #'diff-hl-flydiff/changes)
       (advice-add 'diff-hl-overlay-modified :override #'ignored)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -20,6 +20,9 @@
 
 ;;; Commentary:
 
+;; This mode enables diffing on-the-fly (i.e. without saving the buffer first)
+;; Toggle in all buffers with M-x diff-hl-flydiff-mode
+
 ;;; Code:
 
 (require 'diff-hl)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -188,7 +188,7 @@ This requires the external program `diff' to be in your `exec-path'."
 
     (advice-remove 'diff-hl-update #'diff-hl-flydiff/update)
     (advice-remove 'diff-hl-changes #'diff-hl-flydiff/changes)
-    (advice-remove 'diff-hl-overlay-modified #'ignored)
+    (advice-remove 'diff-hl-overlay-modified #'ignore)
 
     (cancel-timer diff-hl-flydiff-timer)))
 

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -170,8 +170,6 @@ This requires the external program `diff' to be in your `exec-path'."
           ((eq state 'removed)
             `((1 ,(line-number-at-pos (point-max)) delete))))))))
 
-(defun diff-hl-flydiff/overlay-modified (&rest args))
-
 ;;;###autoload
 (define-minor-mode diff-hl-flydiff-mode
   "Highlight diffs on-the-fly"
@@ -180,12 +178,9 @@ This requires the external program `diff' to be in your `exec-path'."
   (if diff-hl-flydiff-mode
     (progn
       (require 'nadvice)
-      (advice-add 'diff-hl-update :around
-        #'diff-hl-flydiff/update)
-      (advice-add 'diff-hl-changes :override
-        #'diff-hl-flydiff/changes)
-      (advice-add 'diff-hl-overlay-modified :override
-        #'diff-hl-flydiff/overlay-modified)
+      (advice-add 'diff-hl-update :around #'diff-hl-flydiff/update)
+      (advice-add 'diff-hl-changes :override #'diff-hl-flydiff/changes)
+      (advice-add 'diff-hl-overlay-modified :override #'ignored)
 
       (remove-hook 'after-change-functions #'diff-hl-edit t)
       (setq diff-hl-flydiff-timer
@@ -193,8 +188,7 @@ This requires the external program `diff' to be in your `exec-path'."
 
     (advice-remove 'diff-hl-update #'diff-hl-flydiff/update)
     (advice-remove 'diff-hl-changes #'diff-hl-flydiff/changes)
-    (advice-remove 'diff-hl-overlay-modified
-      #'diff-hl-flydiff/overlay-modified)
+    (advice-remove 'diff-hl-overlay-modified #'ignored)
 
     (cancel-timer diff-hl-flydiff-timer)
     (when diff-hl-mode

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -109,14 +109,15 @@ This requires the external program `diff' to be in your `exec-path'."
   (interactive)
   (vc-ensure-vc-buffer)
   (with-current-buffer (get-buffer (current-buffer))
-    (let ((rev (diff-hl-flydiff-create-revision
-                 buffer-file-name
-                 (vc-working-revision buffer-file-name
-                   (vc-responsible-backend buffer-file-name))))
-           (temporary-file-directory
-             (if (file-directory-p "/dev/shm/")
-               "/dev/shm/"
-               temporary-file-directory)))
+    (let* ((file buffer-file-name)
+            (temporary-file-directory
+              (if (file-directory-p "/dev/shm/")
+                "/dev/shm/"
+                temporary-file-directory))
+            (rev (diff-hl-flydiff-create-revision
+                   file
+                   (vc-working-revision file
+                     (vc-responsible-backend file)))))
       (diff-no-select rev (current-buffer) "-U 0" 'noasync
         (get-buffer-create " *diff-hl-diff*")))))
 

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -183,7 +183,7 @@ This requires the external program `diff' to be in your `exec-path'."
     (progn
       (advice-add 'diff-hl-update :around #'diff-hl-flydiff/update)
       (advice-add 'diff-hl-changes :override #'diff-hl-flydiff/changes)
-      (advice-add 'diff-hl-overlay-modified :override #'ignored)
+      (advice-add 'diff-hl-overlay-modified :override #'ignore)
 
       (setq diff-hl-flydiff-timer
         (run-with-idle-timer 0.3 t #'diff-hl-update t)))

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -182,7 +182,6 @@ This requires the external program `diff' to be in your `exec-path'."
       (advice-add 'diff-hl-changes :override #'diff-hl-flydiff/changes)
       (advice-add 'diff-hl-overlay-modified :override #'ignored)
 
-      (remove-hook 'after-change-functions #'diff-hl-edit t)
       (setq diff-hl-flydiff-timer
         (run-with-idle-timer 0.3 t #'diff-hl-update t)))
 
@@ -190,8 +189,6 @@ This requires the external program `diff' to be in your `exec-path'."
     (advice-remove 'diff-hl-changes #'diff-hl-flydiff/changes)
     (advice-remove 'diff-hl-overlay-modified #'ignored)
 
-    (cancel-timer diff-hl-flydiff-timer)
-    (when diff-hl-mode
-      (add-hook 'after-change-functions 'diff-hl-edit nil t))))
+    (cancel-timer diff-hl-flydiff-timer)))
 
 (provide 'diff-hl-flydiff)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -32,7 +32,7 @@
 (make-variable-buffer-local 'diff-hl-flydiff-modified-tick)
 
 ;; Polyfill concrete revisions for vc-git-working-revision in Emacs 24.4, 24.5
-(when (version<= emacs-version "24.5")
+(when (version<= emacs-version "25.0")
   (with-eval-after-load 'vc-git
     (defun vc-git--symbolic-ref (file)
       (or

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -209,11 +209,72 @@
 
 (defmacro diff-hl-with-diff-switches (body)
   `(let ((vc-git-diff-switches nil)
-         (vc-hg-diff-switches nil)
-         (vc-svn-diff-switches nil)
-         (vc-diff-switches '("-U0"))
-         (vc-disable-async-diff t))
+          (vc-hg-diff-switches nil)
+          (vc-svn-diff-switches nil)
+          (vc-diff-switches '("-U0"))
+          (vc-disable-async-diff t))
      ,body))
+
+(defun diff-hl-make-temp-file-name (file rev &optional manual)
+  "Return a backup file name for REV or the current version of FILE.
+If MANUAL is non-nil it means that a name for backups created by
+the user should be returned."
+  (let* ((auto-save-file-name-transforms
+           `((".*" ,temporary-file-directory t))))
+    (expand-file-name
+      (concat (make-auto-save-file-name)
+        ".~" (subst-char-in-string
+               ?/ ?_ rev)
+        (unless manual ".") "~")
+      temporary-file-directory)))
+
+(defun diff-hl-create-revision (file revision)
+  "Read REVISION of FILE into a buffer and return the buffer."
+  (let ((automatic-backup (diff-hl-make-temp-file-name file revision))
+         (filebuf (get-file-buffer file))
+         (filename (diff-hl-make-temp-file-name file revision 'manual)))
+    (unless (file-exists-p filename)
+      (if (file-exists-p automatic-backup)
+        (rename-file automatic-backup filename nil)
+        (with-current-buffer filebuf
+          (let ((failed t)
+                 (coding-system-for-read 'no-conversion)
+                 (coding-system-for-write 'no-conversion))
+            (unwind-protect
+              (with-temp-file filename
+                (let ((outbuf (current-buffer)))
+                  ;; Change buffer to get local value of
+                  ;; vc-checkout-switches.
+                  (with-current-buffer filebuf
+                    (vc-call find-revision file revision outbuf))))
+              (setq failed nil)
+              (when (and failed (file-exists-p filename))
+                (delete-file filename)))))))
+    filename))
+
+(defun diff-hl-diff-buffer-with-revision (revision)
+  "View the differences between BUFFER and its associated file.
+This requires the external program `diff' to be in your `exec-path'."
+  (interactive)
+  (vc-ensure-vc-buffer)
+  (with-current-buffer (get-buffer (current-buffer))
+    (let ((rev (diff-hl-create-revision
+                 buffer-file-name
+                 (or revision
+                   (vc-working-revision buffer-file-name
+                     (vc-responsible-backend buffer-file-name)
+                     t))))
+           (temporary-file-directory
+             (if (file-directory-p "/dev/shm/")
+               "/dev/shm/"
+               temporary-file-directory)))
+      (diff-hl-with-diff-switches
+        (diff-no-select rev (current-buffer) "-U 0" 'noasync
+          (get-buffer-create " *diff-hl-diff*"))))))
+
+(defvar diff-hl-modified-tick 0)
+(defvar diff-hl-flydiff-timer)
+(make-variable-buffer-local 'diff-hl-modified-tick)
 
 (defun diff-hl-changes ()
   (let* ((file buffer-file-name)
@@ -221,77 +282,82 @@
     (when backend
       (let ((state (vc-state file backend)))
         (cond
-         ((or (eq state 'edited)
-              (and (eq state 'up-to-date)
-                   ;; VC state is stale in after-revert-hook.
-                   (or revert-buffer-in-progress-p
-                       ;; Diffing against an older revision.
-                       diff-hl-reference-revision)))
-          (let* ((buf-name " *diff-hl* ")
-                 diff-auto-refine-mode
-                 res)
-            (diff-hl-with-diff-switches
-             (vc-call-backend backend 'diff (list file)
-                              diff-hl-reference-revision nil
-                              buf-name))
-            (with-current-buffer buf-name
-              (goto-char (point-min))
-              (unless (eobp)
-                (ignore-errors
-                  (diff-beginning-of-hunk t))
-                (while (looking-at diff-hunk-header-re-unified)
-                  (let ((line (string-to-number (match-string 3)))
-                        (len (let ((m (match-string 4)))
-                               (if m (string-to-number m) 1)))
-                        (beg (point)))
-                    (diff-end-of-hunk)
-                    (let* ((inserts (diff-count-matches "^\\+" beg (point)))
-                           (deletes (diff-count-matches "^-" beg (point)))
-                           (type (cond ((zerop deletes) 'insert)
-                                       ((zerop inserts) 'delete)
-                                       (t 'change))))
-                      (when (eq type 'delete)
-                        (setq len 1)
-                        (cl-incf line))
-                      (push (list line len type) res))))))
-            (nreverse res)))
-         ((eq state 'added)
-          `((1 ,(line-number-at-pos (point-max)) insert)))
-         ((eq state 'removed)
-          `((1 ,(line-number-at-pos (point-max)) delete))))))))
+          ((or
+             (and
+               diff-hl-flydiff-mode
+               (buffer-modified-p))
+             (eq state 'edited)
+             (and (eq state 'up-to-date)
+               ;; VC state is stale in after-revert-hook.
+               (or revert-buffer-in-progress-p
+                 ;; Diffing against an older revision.
+                 diff-hl-reference-revision)))
+            (let (diff-auto-refine-mode res)
+              (with-current-buffer (diff-hl-diff-buffer-with-revision
+                                     diff-hl-reference-revision)
+                (goto-char (point-min))
+                (unless (eobp)
+                  (ignore-errors
+                    (diff-beginning-of-hunk t))
+                  (while (looking-at diff-hunk-header-re-unified)
+                    (let ((line (string-to-number (match-string 3)))
+                           (len (let ((m (match-string 4)))
+                                  (if m (string-to-number m) 1)))
+                           (beg (point)))
+                      (diff-end-of-hunk)
+                      (let* ((inserts (diff-count-matches "^\\+" beg (point)))
+                              (deletes (diff-count-matches "^-" beg (point)))
+                              (type (cond ((zerop deletes) 'insert)
+                                      ((zerop inserts) 'delete)
+                                      (t 'change))))
+                        (when (eq type 'delete)
+                          (setq len 1)
+                          (cl-incf line))
+                        (push (list line len type) res))))))
+              (setq diff-hl-modified-tick (buffer-modified-tick))
+              (nreverse res)))
+          ((eq state 'added)
+            `((1 ,(line-number-at-pos (point-max)) insert)))
+          ((eq state 'removed)
+            `((1 ,(line-number-at-pos (point-max)) delete))))))))
 
-(defun diff-hl-update ()
-  (let ((changes (diff-hl-changes))
-        (current-line 1))
-    (diff-hl-remove-overlays)
-    (save-excursion
-      (save-restriction
-        (widen)
-        (goto-char (point-min))
-        (dolist (c changes)
-          (cl-destructuring-bind (line len type) c
-            (forward-line (- line current-line))
-            (setq current-line line)
-            (let ((hunk-beg (point)))
-              (while (cl-plusp len)
-                (diff-hl-add-highlighting
-                  type
-                 (cond
-                  ((not diff-hl-draw-borders) 'empty)
-                  ((and (= len 1) (= line current-line)) 'single)
-                  ((= len 1) 'bottom)
-                  ((= line current-line) 'top)
-                  (t 'middle)))
-                (forward-line 1)
-                (cl-incf current-line)
-                (cl-decf len))
-              (let ((h (make-overlay hunk-beg (point)))
-                    (hook '(diff-hl-overlay-modified)))
-                (overlay-put h 'diff-hl t)
-                (overlay-put h 'diff-hl-hunk t)
-                (overlay-put h 'modification-hooks hook)
-                (overlay-put h 'insert-in-front-hooks hook)
-                (overlay-put h 'insert-behind-hooks hook)))))))))
+(defun diff-hl-update (&optional auto)
+  (unless (and auto
+            (or
+              (= diff-hl-modified-tick (buffer-modified-tick))
+              (file-remote-p default-directory)
+              (not (buffer-modified-p))))
+    (let ((changes (diff-hl-changes))
+           (current-line 1))
+      (diff-hl-remove-overlays)
+      (save-excursion
+        (save-restriction
+          (widen)
+          (goto-char (point-min))
+          (dolist (c changes)
+            (cl-destructuring-bind (line len type) c
+              (forward-line (- line current-line))
+              (setq current-line line)
+              (let ((hunk-beg (point)))
+                (while (cl-plusp len)
+                  (diff-hl-add-highlighting
+                    type
+                    (cond
+                      ((not diff-hl-draw-borders) 'empty)
+                      ((and (= len 1) (= line current-line)) 'single)
+                      ((= len 1) 'bottom)
+                      ((= line current-line) 'top)
+                      (t 'middle)))
+                  (forward-line 1)
+                  (cl-incf current-line)
+                  (cl-decf len))
+                (let ((h (make-overlay hunk-beg (point)))
+                       (hook '(diff-hl-overlay-modified)))
+                  (overlay-put h 'diff-hl t)
+                  (overlay-put h 'diff-hl-hunk t)
+                  (overlay-put h 'modification-hooks hook)
+                  (overlay-put h 'insert-in-front-hooks hook)
+                  (overlay-put h 'insert-behind-hooks hook))))))))))
 
 (defun diff-hl-add-highlighting (type shape)
   (let ((o (make-overlay (point) (point))))
@@ -311,7 +377,9 @@
 
 (defun diff-hl-overlay-modified (ov after-p _beg _end &optional _length)
   "Delete the hunk overlay and all our line overlays inside it."
-  (unless after-p
+  (unless (or
+            diff-hl-flydiff-mode
+            after-p)
     (when (overlay-buffer ov)
       (diff-hl-remove-overlays (overlay-start ov) (overlay-end ov))
       (delete-overlay ov))))
@@ -475,6 +543,8 @@ in the source file, or the last line of the hunk above it."
         (add-hook 'magit-not-reverted-hook 'diff-hl-update nil t)
         (add-hook 'auto-revert-mode-hook 'diff-hl-update nil t)
         (add-hook 'text-scale-mode-hook 'diff-hl-define-bitmaps nil t))
+
+    (diff-hl-flydiff-mode -1)
     (remove-hook 'after-save-hook 'diff-hl-update t)
     (remove-hook 'after-change-functions 'diff-hl-edit t)
     (remove-hook 'find-file-hook 'diff-hl-update t)
@@ -536,6 +606,20 @@ in the source file, or the last line of the hunk above it."
         (when diff-hl-dir-mode
           (diff-hl-dir-mode -1))))))
 
-(provide 'diff-hl)
+(define-minor-mode diff-hl-flydiff-mode
+  "Highlight diffs on-the-fly"
+  :lighter ""
+  (if diff-hl-flydiff-mode
+    (progn
+      (unless (or
+                diff-hl-mode
+                diff-hl-dir-mode)
+        (turn-on-diff-hl-mode))
+      (remove-hook 'after-change-functions #'diff-hl-edit t)
+      (setq diff-hl-flydiff-timer
+        (run-with-idle-timer 0.3 t #'diff-hl-update t)))
+    (cancel-timer diff-hl-flydiff-timer)
+    (add-hook 'after-change-functions 'diff-hl-edit nil t)))
 
+(provide 'diff-hl)
 ;;; diff-hl.el ends here


### PR DESCRIPTION
See #33 

This isn't quite ready. It doesn't have the following advice for the two `vc` functions.
```emacs
(with-eval-after-load 'vc
  (defun nadvice/vc-working-revision (file &optional backend concrete)
    (if concrete
      (vc-call-backend backend 'working-revision file t)
      (or (vc-file-getprop file 'vc-working-revision)
        (progn
          (setq backend (or backend (vc-responsible-backend file)))
          (when backend
            (vc-file-setprop file 'vc-working-revision
              (vc-call-backend backend 'working-revision file)))))))
  (advice-add #'vc-working-revision :override #'nadvice/vc-working-revision))

(with-eval-after-load 'vc-git
  (defun nadvice/vc-git-working-revision (old-fun file &optional concrete)
    "Git-specific version of `vc-working-revision'."
    (if concrete
      (vc-git--rev-parse (funcall old-fun file))
      (funcall old-fun file)))

  (advice-add #'vc-git-working-revision :around
    #'nadvice/vc-git-working-revision))
```

Will I

1. Commit some variant of these to the Emacs codebase and disallow `diff-hl-flydiff-mode` on all versions up to but not including the patched one?
2. Commit the code to Emacs, and keep some advice in `diff-hl` that:
  1. Switches on the Emacs version?
  2. Switches on some sort of feature detection?

This has passed my initial testing with the above advice, so things seem to be going well.