### PR TITLE
Define diff-hl-command-map without destroying existing bindings

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -437,13 +437,14 @@ in the source file, or the last line of the hunk above it."
   (interactive)
   (diff-hl-next-hunk t))
 
-(define-prefix-command 'diff-hl-command-map)
+(defvar diff-hl-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "n" 'diff-hl-revert-hunk)
+    (define-key map "[" 'diff-hl-previous-hunk)
+    (define-key map "]" 'diff-hl-next-hunk)
+    map))
 
-(let ((map diff-hl-command-map))
-  (define-key map "n" 'diff-hl-revert-hunk)
-  (define-key map "[" 'diff-hl-previous-hunk)
-  (define-key map "]" 'diff-hl-next-hunk)
-  map)
+(fset 'diff-hl-command-map diff-hl-command-map)
 
 ;;;###autoload
 (define-minor-mode diff-hl-mode


### PR DESCRIPTION
```
Keymaps are usually defined using `defvar' which has the advantage that
it only sets a variables value if that is not defined yet.  As a result
re-evaluating (i.e. during development) a buffer that contains such a
definition does not reset the value, which would lose all user
customization.

Unfortunately `define-prefix-command' does not do that.  So use `defvar'
to define the variable and then also store the keymap in the function
cell using `fset'.
```