### PR TITLE
Check that buffer is mapped to file

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -538,6 +538,7 @@ in the source file, or the last line of the hunk above it."
     (dolist (buf (buffer-list))
       (when (and (buffer-local-value 'diff-hl-mode buf)
                  (not (buffer-modified-p buf))
+                 (buffer-file-name buf)
                  (file-in-directory-p (buffer-file-name buf) topdir))
         (with-current-buffer buf
           (let* ((file buffer-file-name)


### PR DESCRIPTION
Certain buffers (as is the case with the Magit buffer) are not mapped to files in the file system.

Running `diff-hl-magit-post-refresh` on these buffers will cause `Wrong type argument: stringp, nil.`

It happens because I mapped `diff-hl-mode` to `prog-mode-hook`.