### PR TITLE
Fix revert prompt

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -418,7 +418,7 @@ in the source file, or the last line of the hunk above it."
                   (recenter 1)))
               (when diff-auto-refine-mode
                 (diff-refine-hunk))
-              (unless (yes-or-no-p (format "Revert current hunk in %s?"
+              (unless (yes-or-no-p (format "Revert current hunk in %s? "
                                            ,(cl-caadr fileset)))
                 (error "Revert canceled"))
               (let ((diff-advance-after-apply-hunk nil))


### PR DESCRIPTION
The ‘yes-or-no-p’ procedure doesn’t pad its prompt argument with a
space so before this commit the prompt becomes:

    Revert current hunk in <file>?(yes or no)

After this commit the prompt gets fixed to:

    Revert current hunk in <file>? (yes or no)