### PR TITLE
Use `user-error` when we can't proceed

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -6,7 +6,7 @@
 ;; URL:      https://github.com/dgutov/diff-hl
 ;; Keywords: vc, diff
 ;; Version:  1.8.4
-;; Package-Requires: ((cl-lib "0.2"))
+;; Package-Requires: ((cl-lib "0.2") (emacs "24.3"))
 
 ;; This file is part of GNU Emacs.
 
@@ -399,7 +399,7 @@ in the source file, or the last line of the hunk above it."
            `(let (beg-line end-line)
               (when (eobp)
                 (with-current-buffer ,buffer (diff-hl-remove-overlays))
-                (error "Buffer is up-to-date"))
+                (user-error "Buffer is up-to-date"))
               (let (diff-auto-refine-mode)
                 (diff-hl-diff-skip-to ,line))
               (save-excursion
@@ -420,7 +420,7 @@ in the source file, or the last line of the hunk above it."
                 (diff-refine-hunk))
               (unless (yes-or-no-p (format "Revert current hunk in %s? "
                                            ,(cl-caadr fileset)))
-                (error "Revert canceled"))
+                (user-error "Revert canceled"))
               (let ((diff-advance-after-apply-hunk nil))
                 (diff-apply-hunk t))
               (with-current-buffer ,buffer
@@ -447,7 +447,7 @@ in the source file, or the last line of the hunk above it."
                        (throw 'found (overlay-start o)))))))))
     (if pos
         (goto-char pos)
-      (error "No further hunks found"))))
+      (user-error "No further hunks found"))))
 
 (defun diff-hl-previous-hunk ()
   "Go to the beginning of the previous hunk in the current buffer."
@@ -458,7 +458,7 @@ in the source file, or the last line of the hunk above it."
   (interactive)
   (let ((hunk (diff-hl-hunk-overlay-at (point))))
     (unless hunk
-      (error "No hunk at point"))
+      (user-error "No hunk at point"))
     (goto-char (overlay-start hunk))
     (push-mark (overlay-end hunk) nil t)))
 


### PR DESCRIPTION
In these situations, it's not a bug with the code, and opening the emacs
debugger is not useful. By using `user-error`, the debugger is not
activated but we still terminate with an informative message.