### PR TITLE
Don't attempt to highlight in a file that doesn't exist

### DIFF
--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -140,6 +140,7 @@ This requires the external program `diff' to be in your `exec-path'."
   (unless (or
            (not diff-hl-mode)
            (= diff-hl-flydiff-modified-tick (buffer-modified-tick))
+           (not (file-exists-p (buffer-file-name)))
            (file-remote-p default-directory))
     (diff-hl-update)))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -549,7 +549,8 @@ The value of this variable is a mode line template as in
                  ;; (diff-hl-mode could be non-nil there, even if
                  ;; buffer-file-name is nil):
                  (buffer-file-name buf)
-                 (file-in-directory-p (buffer-file-name buf) topdir))
+                 (file-in-directory-p (buffer-file-name buf) topdir)
+                 (file-exists-p (buffer-file-name buf)))
         (with-current-buffer buf
           (let* ((file buffer-file-name)
                  (backend (vc-backend file)))


### PR DESCRIPTION
If the buffer is associated with a file that is moved to a different
directory, but outside of Emacs, we previously crashed:

    Debugger entered--Lisp error: (file-error "Setting current directory" "No such file or directory" "/Users/whughes/redacted/")
      call-process("git" nil (t nil) nil "diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml")
      apply(call-process "git" nil (t nil) nil ("diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml"))
      process-file("git" nil (t nil) nil "diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml")
      apply(process-file "git" nil (t nil) nil "diff-index" ("-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml"))
      vc-git--call((t nil) "diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml")
      apply(vc-git--call (t nil) "diff-index" ("-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml"))
      vc-git--out-ok("diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml")
      apply(vc-git--out-ok ("diff-index" "-p" "--raw" "-z" "HEAD" "--" "docker-compose.yml"))
      vc-git--run-command-string("/Users/whughes/redacted/docker-compose.yml" "diff-index" "-p" "--raw" "-z" "HEAD" "--")
      vc-git-state("/Users/whughes/redacted/docker-compose.yml")
      apply(vc-git-state "/Users/whughes/redacted/docker-compose.yml")
      vc-call-backend(Git state "/Users/whughes/redacted/docker-compose.yml")
      vc-state-refresh("/Users/whughes/redacted/docker-compose.yml" Git)
      vc-state("/Users/whughes/redacted/docker-compose.yml" Git)
      (let ((state (vc-state file backend))) (cond ((diff-hl-modified-p state) (let* (diff-auto-refine-mode res) (save-current-buffer (set-buffer (diff-hl-changes-buffer file backend)) (goto-char (point-min)) (if (eobp) nil (condition-case nil (progn ...) (error nil)) (while (looking-at diff-hunk-header-re-unified) (let ... ... ...)))) (nreverse res))) ((eq state (quote added)) (list (cons 1 (cons (line-number-at-pos (point-max)) (quote (insert)))))) ((eq state (quote removed)) (list (cons 1 (cons (line-number-at-pos (point-max)) (quote (delete))))))))
      (progn (let ((state (vc-state file backend))) (cond ((diff-hl-modified-p state) (let* (diff-auto-refine-mode res) (save-current-buffer (set-buffer (diff-hl-changes-buffer file backend)) (goto-char (point-min)) (if (eobp) nil (condition-case nil ... ...) (while ... ...))) (nreverse res))) ((eq state (quote added)) (list (cons 1 (cons (line-number-at-pos ...) (quote ...))))) ((eq state (quote removed)) (list (cons 1 (cons (line-number-at-pos ...) (quote ...))))))))
      (if backend (progn (let ((state (vc-state file backend))) (cond ((diff-hl-modified-p state) (let* (diff-auto-refine-mode res) (save-current-buffer (set-buffer ...) (goto-char ...) (if ... nil ... ...)) (nreverse res))) ((eq state (quote added)) (list (cons 1 (cons ... ...)))) ((eq state (quote removed)) (list (cons 1 (cons ... ...))))))))
      (let* ((file buffer-file-name) (backend (vc-backend file))) (if backend (progn (let ((state (vc-state file backend))) (cond ((diff-hl-modified-p state) (let* (diff-auto-refine-mode res) (save-current-buffer ... ... ...) (nreverse res))) ((eq state (quote added)) (list (cons 1 ...))) ((eq state (quote removed)) (list (cons 1 ...))))))))
      diff-hl-changes()
      (let ((changes (diff-hl-changes)) (current-line 1)) (diff-hl-remove-overlays) (save-excursion (save-restriction (widen) (goto-char (point-min)) (let ((--dolist-tail-- changes)) (while --dolist-tail-- (let ((c ...)) (let* (... ... ... ...) (progn ... ... ...)) (setq --dolist-tail-- (cdr --dolist-tail--))))))))
      diff-hl-update()
      (if (or (not diff-hl-mode) (= diff-hl-flydiff-modified-tick (buffer-modified-tick)) (file-remote-p default-directory)) nil (diff-hl-update))
      diff-hl-flydiff-update()
      apply(diff-hl-flydiff-update nil)
      timer-event-handler([t 0 0 299999 t diff-hl-flydiff-update nil idle 999999])

Instead, don't highlight anything if the file stops existing.