### PR TITLE
Set reference rev in change log buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The package also contains auxiliary modes:
 * `diff-hl-dired-mode` provides similar functionality in Dired.
 * `diff-hl-margin-mode` changes the highlighting function to
   use the margin instead of the fringe.
-* `diff-hl-amend-mode` shifts the reference revision back by one.
+* `diff-hl-amend-mode` sets the reference revision to the one before
+  recent one. Also, you could use `diff-hl-log-view-set-reference-rev`
+  to set it to any revision, see its docstring for details.
 * `diff-hl-flydiff-mode` implements highlighting changes on the fly.
   It requires Emacs 24.4 or newer.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The package also contains auxiliary modes:
 * `diff-hl-margin-mode` changes the highlighting function to
   use the margin instead of the fringe.
 * `diff-hl-amend-mode` sets the reference revision to the one before
-  recent one. Also, you could use `diff-hl-log-view-set-reference-rev`
-  to set it to any revision, see its docstring for details.
+  recent one. Also, you could use `diff-hl-set-reference-rev` to set
+  it to any revision, see its docstring for details.
 * `diff-hl-flydiff-mode` implements highlighting changes on the fly.
   It requires Emacs 24.4 or newer.
 

--- a/diff-hl-amend.el
+++ b/diff-hl-amend.el
@@ -39,7 +39,7 @@ Currently only supports Git, Mercurial and Bazaar."
         (diff-hl-amend-setup)
         (add-hook 'after-revert-hook 'diff-hl-amend-setup nil t))
     (remove-hook 'after-revert-hook 'diff-hl-amend-setup t)
-    (setq-local diff-hl-reference-revision nil))
+    (kill-local-variable 'diff-hl-reference-revision))
   (when diff-hl-mode
     (diff-hl-update)))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -35,6 +35,8 @@
 ;; `diff-hl-revert-hunk'     C-x v n
 ;; `diff-hl-previous-hunk'   C-x v [
 ;; `diff-hl-next-hunk'       C-x v ]
+;; `diff-hl-log-view-set-reference-rev'
+;; `diff-hl-reset-reference-rev'
 ;;
 ;; The mode takes advantage of `smartrep' if it is installed.
 
@@ -686,88 +688,37 @@ The value of this variable is a mode line template as in
     (turn-on-diff-hl-mode)))
 
 ;;;###autoload
-(defun diff-hl-log-view-set-reference-rev-for-fileset ()
-  "In *vc-change-log* buffer, set current as reference revision.
-Call `vc-print-log' first, then use this command on a revision,
-`diff-hl' will show changes against this revision for this file."
+(defun diff-hl-log-view-set-reference-rev ()
+  "In *vc-change-log* buffer, set the current one as reference revision.
+Call `vc-print-log' or `vc-print-root-log' first, then use this
+command on a revision, `diff-hl-mode' will show changes against
+this revision.
+
+Notice that this sets the reference revision globally, so in
+files from other repositories, `diff-hl-mode' will not highlight
+changes correctly, until you run `diff-hl-reset-reference-rev'.
+
+Also notice that `diff-hl-amend-mode' will override this.
+Disable it to reveal the effect of this command."
   (interactive)
-  ;; For some reason `log-view-current-tag' has to be called before
-  ;; `vc-deduce-fileset'.
-  (let* ((rev (log-view-current-tag))
-         (fileset (nth 1 (vc-deduce-fileset)))
-         (bufs (mapcar #'get-file-buffer fileset))
-         (bufs (cl-delete nil bufs)))
+  (let* ((rev (log-view-current-tag)))
     (unless rev
       (user-error "Not in a change log buffer"))
-    (unless bufs
-      (user-error "Files in the fileset are all closed"))
-    (dolist (buf bufs)
-      (with-current-buffer buf
-        (setq-local diff-hl-reference-revision rev)))))
+    (setq diff-hl-reference-revision rev))
+  (dolist (buf (buffer-list))
+    (with-current-buffer buf
+      (when diff-hl-mode
+        (diff-hl-update)))))
 
 ;;;###autoload
-(defun diff-hl-reset-reference-rev-for-fileset ()
-  "Use most recent revision as reference for current fileset."
+(defun diff-hl-reset-reference-rev ()
+  "Reset the reference revision globally to the most recent one."
   (interactive)
-  "Use most recent revision as reference for current fileset."
-  (let* ((fileset (nth 1 (vc-deduce-fileset)))
-         (bufs (mapcar #'get-file-buffer fileset))
-         (bufs (cl-delete nil bufs)))
-    (unless bufs
-      (user-error "Files in the fileset are all closed"))
-    (dolist (buf bufs)
-      (with-current-buffer buf
-        (setq-local diff-hl-reference-revision nil)))))
-
-;;;###autoload
-(defun diff-hl-log-view-set-reference-rev-for-repo ()
-  "In *vc-change-log* buffer, set current as reference revision.
-Call `vc-print-root-log' first, then use this command on a
-revision, `diff-hl' will show changes against this revision for
-all files in the repo."
-  (interactive)
-  (let* ((rev (log-view-current-tag))
-         (repo (vc-root-dir))
-         bufs)
-    (unless rev
-      (user-error "Not in a change log buffer"))
-    ;; If we are in a change log buffer, `repo' would not be nil, so it's safe
-    ;; to run `expand-file-name' on it.
-    (setq repo (expand-file-name repo))
-    (dolist (buf (buffer-list))
-      (with-current-buffer buf
-        (let* ((filename (buffer-file-name))
-               (filename (when (stringp filename)
-                           (expand-file-name filename))))
-          (when (and filename (string-prefix-p repo filename))
-            (push buf bufs)))))
-    (unless bufs
-      (user-error "Files in the repo are all closed"))
-    (dolist (buf bufs)
-      (with-current-buffer buf
-        (setq-local diff-hl-reference-revision rev)))))
-
-;;;###autoload
-(defun diff-hl-reset-reference-rev-for-repo ()
-  "Use most recent revision as reference for current repo."
-  (interactive)
-  (let* ((repo (vc-root-dir))
-         bufs)
-    (unless repo
-      (user-error "Not in a repo"))
-    (setq repo (expand-file-name repo))
-    (dolist (buf (buffer-list))
-      (with-current-buffer buf
-        (let* ((filename (buffer-file-name))
-               (filename (when (stringp filename)
-                           (expand-file-name filename))))
-          (when (and filename (string-prefix-p repo filename))
-            (push buf bufs)))))
-    (unless bufs
-      (user-error "Files in the repo are all closed"))
-    (dolist (buf bufs)
-      (with-current-buffer buf
-        (setq-local diff-hl-reference-revision nil)))))
+  (setq diff-hl-reference-revision nil)
+  (dolist (buf (buffer-list))
+    (with-current-buffer buf
+      (when diff-hl-mode
+        (diff-hl-update)))))
 
 ;;;###autoload
 (define-globalized-minor-mode global-diff-hl-mode diff-hl-mode


### PR DESCRIPTION
Solves #134.

Usage: 

- `M-x vc-print-log`, then run `diff-hl-log-view-set-reference-rev-for-fileset` on a rev to set it as the reference for the fie. Run `diff-hl-reset-reference-rev-for-fileset` to reset.
- `M-x vc-print-root-log`, then run `diff-hl-log-view-set-reference-rev-for-repo` on a rev to set it as the reference for all files in the repo. Run `diff-hl-reset-reference-rev-for-repo` to reset.

I'll write the usage in README after we are done with the code.

Problems:

- I am not familiar with the `fileset` concept of `vc`. To me it's like always being the current file. If this is right, I'll change the command name and docstring to make more sense for the users.
- For some reason, after setting the reference rev, I have to disable and enable `diff-hl-mode` in the file buffers for it to take effect.
- Set reference rev for repo doesn't affect newly opened files in that repo. Maybe we could set up some hook to do this.