### PR TITLE
Add global-diff-hl-amend-mode to diff-hl custom group

### DIFF
--- a/diff-hl-amend.el
+++ b/diff-hl-amend.el
@@ -57,7 +57,8 @@ Currently only supports Git, Mercurial and Bazaar."
 
 ;;;###autoload
 (define-globalized-minor-mode global-diff-hl-amend-mode diff-hl-amend-mode
-  turn-on-diff-hl-amend-mode)
+  turn-on-diff-hl-amend-mode
+  :group 'diff-hl)
 
 (defun turn-on-diff-hl-amend-mode ()
   "Turn on `diff-hl-amend-mode' in a buffer if appropriate."


### PR DESCRIPTION
Emacs 28's byte-compiler was complaining about it not
being a member of any group.