### PR TITLE
Use vc-read-revision in some cases set-reference-rev can't deduce the revision

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -725,7 +725,7 @@ The value of this variable is a mode line template as in
                                             nil
                                             at-point
                                             nil))
-                        (thing-at-point 'symbol t))))
+                        at-point)))
     (when (string= "" revision)
       (user-error "Empty revision"))
     revision))


### PR DESCRIPTION
I think the revision deduction process of `diff-hl-set-reference-rev` can be improved if `vc-read-revision` is used when in a vc-backed buffer.

It seems to work with and without [helm](https://emacs-helm.github.io/helm/). I have not tested it with other completion frameworks.