### PR TITLE
remove unused `buffer` argument in diff-hl-make-temp-file-name

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -729,7 +729,7 @@ The value of this variable is a mode line template as in
       (add-hook 'vc-checkin-hook 'diff-hl-dir-update t t)
     (remove-hook 'vc-checkin-hook 'diff-hl-dir-update t)))
 
-(defun diff-hl-make-temp-file-name (buffer rev &optional manual)
+(defun diff-hl-make-temp-file-name (rev &optional manual)
   "Return a backup file name for REV or the current version of BUFFER.
 If MANUAL is non-nil it means that a name for backups created by
 the user should be returned."
@@ -744,9 +744,9 @@ the user should be returned."
 
 (defun diff-hl-create-revision (file revision)
   "Read REVISION of BUFFER into a buffer and return the buffer."
-  (let ((automatic-backup (diff-hl-make-temp-file-name file revision))
+  (let ((automatic-backup (diff-hl-make-temp-file-name revision))
         (filebuf (get-file-buffer file))
-        (filename (diff-hl-make-temp-file-name file revision 'manual)))
+        (filename (diff-hl-make-temp-file-name revision 'manual)))
     (unless (file-exists-p filename)
       (if (file-exists-p automatic-backup)
           (rename-file automatic-backup filename nil)


### PR DESCRIPTION
`buffer` argument of `diff-hl-make-temp-file-name` was unused.

Emacs byte compiler started complaining about an unused lexical argument, perhaps due to the [new-ish byte-compiler check for missing dynamic variable declarations](https://github.com/emacs-mirror/emacs/blob/3a7702135377402015368c8307503b62c421655c/etc/NEWS#L2620)??

Occurred on:

Emacs 28.1 compiled from source origin/master branch on 27-02-2021 on Ubuntu 18.04

Configured with `--with-mailutils --with-imagemagick --with-xwidgets`, all the rest is default.

`GNU Emacs 28.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30, cairo version 1.15.10)
of 2021-02-27`