### PR TITLE
Prevent diff-hl-side from triggering infloop

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -131,6 +131,7 @@
   "Which side to use for indicators."
   :type '(choice (const left)
                  (const right))
+  :initialize 'custom-initialize-default
   :set (lambda (var value)
          (let ((on (bound-and-true-p global-diff-hl-mode)))
            (when on (global-diff-hl-mode -1))


### PR DESCRIPTION
When `diff-hl.el` is being loaded, and this defcustom is being defined, it is possible the setter will encounter a variable `global-diff-hl-mode` that is both bound and true, maybe due to a customs file with a `(custom-set-variable '(global-diff-hl-mode t))` in it being loaded before `diff-hl.el`. Therefore, during this defcustom definition, the default initializer will call the setting, which will attempt to call an autoloaded function `global-diff-hl-mode`, which will trigger another load of `diff-hl.el`, ad infinitum.

This PR uses the suggested fix in the [elisp manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Variable-Definitions.html) to only call the setter during customization.