### PR TITLE
Last line of inline-popup properly underlined in terminal.

### DIFF
--- a/diff-hl-inline-popup.el
+++ b/diff-hl-inline-popup.el
@@ -104,8 +104,8 @@ Default for CONTENT-SIZE is the size of the current lines"
          (new-width (- width (length footer) (length scroll-indicator)))
          (blank-line (if (display-graphic-p)
                          ""
-                       (propertize (concat "\n" (diff-hl-inline-popup--separator width))
-                                   'face '(:underline t))))
+                       (concat "\n" (propertize (diff-hl-inline-popup--separator width)
+                                   'face '(:underline t)))))
          (line (propertize (concat (diff-hl-inline-popup--separator new-width)
                                    footer scroll-indicator)
                            'face '(:overline t))))

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -310,10 +310,11 @@ of `diff-hl-show-hunk'."
 (defun diff-hl-show-hunk--goto-hunk-overlay (overlay)
   "Tries to display the whole overlay, and place the point at the
 end of the OVERLAY, so posframe/inline is placed below the hunk."
-  (goto-char (overlay-start overlay))
-  (when (< (point) (window-start))
-    (set-window-start nil (point)))
-  (goto-char (1- (overlay-end overlay))))
+  (when (and (overlayp overlay) (overlay-buffer overlay))
+    (goto-char (overlay-start overlay))
+    (when (< (point) (window-start))
+      (set-window-start nil (point)))
+    (goto-char (1- (overlay-end overlay)))))
 
 ;;;###autoload
 (defun diff-hl-show-hunk-next ()


### PR DESCRIPTION
This minor change fixes the last line of the inline popup in terminal. The last content line had an extra underlined character at the end.

Also, `diff-hl-show-hunk--goto-hunk-overlay` is now more tolerant to previous errors.