### PR TITLE
Fix building libraries using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,24 @@
 EMACS ?= emacs
-SOURCES=
+SOURCES=diff-hl.el
 SOURCES+=diff-hl-amend.el
 SOURCES+=diff-hl-dired.el
 SOURCES+=diff-hl-flydiff.el
+SOURCES+=diff-hl-inline-popup.el
 SOURCES+=diff-hl-margin.el
+SOURCES+=diff-hl-show-hunk-posframe.el
+SOURCES+=diff-hl-show-hunk.el
 
 ARTIFACTS=$(patsubst %.el, %.elc, $(SOURCES))
 
 RM ?= rm -f
 
-all: test
+all: compile test
 
 test:
 	$(EMACS) -batch -L . -l test/diff-hl-test.el -f diff-hl-run-tests
 
 compile:
-	$(EMACS) -batch -f batch-byte-compile $(SOURCES)
+	$(EMACS) -batch -L . -f batch-byte-compile $(SOURCES)
 
 clean:
 	$(RM) $(ARTIFACTS)


### PR DESCRIPTION
- Compile all libraries, including the main one.
- Make the "all" make target depend on "compile".
- Add the current directory to the load-path,
  so that compiling doesn't fail completely.