### PR TITLE
Silence byte-compiler

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -885,6 +885,8 @@ the `diff-program' to be in your `exec-path'."
               (t (memq major-mode diff-hl-global-modes)))
     (turn-on-diff-hl-mode)))
 
+(declare-function vc-annotate-extract-revision-at-line "vc-annotate")
+
 ;;;###autoload
 (defun diff-hl-set-reference-rev (rev)
   "Set the reference revision globally to REV.


### PR DESCRIPTION
The byte-compiler has a second complaint, which this pr does *not* tackle:

```
In diff-hl-changes-from-buffer:
lib/diff-hl/diff-hl.el:332:12: Warning: ‘diff-auto-refine-mode’ is an obsolete
    function (as of 27.1); set ‘diff-refine’ instead.
```

This is weird because that is used as a *variable*, not a function.  Sure, the variable is obsolete too, but the byte-compiler seems confused.  Or can you see what's going on?

Anyway, this could be suppressed by wrapping the `let[*]` with `with-no-warnings`.  But maybe the scope of that could be reduced to avoid accidentally suppressing other legitimate warnings in the future?

Could you please take care of this please? I regularly recompile all the packages I have installed and try to fix all the new warnings, but this is a hairy case that I think the maintainer should investigate instead.

Thanks!