### PR TITLE
Mention that VC must be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Put this into your init script:
 (global-diff-hl-mode)
 ```
 
+You must also ensure that VC is enabled (e.g. `vc-handled-backends` is
+not nil).
+
 Check out the Commentary section in each file for more detailed usage
 instructions.
 


### PR DESCRIPTION
Some people disable VC because it fixes various oddities in Emacs and the same features are provided by other packages such as Magit. In this case, diff-hl will silently do nothing, which is confusing. This PR adds a note to the README clarifying the requirements for using diff-hl.