### PR TITLE
Add new option diff-hl-disable-on-remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,12 @@ When using Magit 2.4 or newer, add this to your init script:
 (add-hook 'magit-pre-refresh-hook 'diff-hl-magit-pre-refresh)
 (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
 ```
+
+Tramp
+-----
+
+`diff-hl` should just work with Tramp. But sometimes a performance
+penalty may be experienced in slow or high latency connections. If
+you experiment such issue then an option may be to set
+`diff-hl-disable-on-remote` to `t` this will inhibit some `diff-hl`
+actions and hooks for the remote buffers.


### PR DESCRIPTION
To inhibit diff-hl in remote buffers. This option is useful with slow
tramp connections.