### PR TITLE
Use line-beginning-position instead of obsolete point-at-bol

### DIFF
--- a/diff-hl-inline-popup.el
+++ b/diff-hl-inline-popup.el
@@ -247,7 +247,7 @@ is closed."
 
   (when (< (diff-hl-inline-popup--compute-content-height 99) 2)
     (user-error "There is no enough vertical space to show the inline popup"))
-  (let* ((the-point (or point (point-at-eol)))
+  (let* ((the-point (or point (line-end-position)))
          (the-buffer (current-buffer))
          (overlay (make-overlay the-point the-point the-buffer)))
     (overlay-put overlay 'phantom t)

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -179,7 +179,9 @@ Returns a list with the buffer and the line number of the clicked line."
 
       ;; Highlight the clicked line
       (goto-char point-in-buffer)
-      (setq line-overlay (make-overlay (point-at-bol) (min (point-max) (1+ (point-at-eol)))))
+      (setq line-overlay (make-overlay (line-beginning-position)
+                                       (min (point-max)
+                                            (1+ (line-end-position)))))
 
       ;; diff-mode
       (diff-mode)


### PR DESCRIPTION
Likewise use line-end-position instead of obsolete point-at-eol.

Obsolete since Emacs 29 / b7e867b841f47dcff3aeaef9b5608a237386ce70.