### PR TITLE
Prevent Tramp and `diff-hl-flydiff-mode` from making Emacs unusable if the remote host disappears

### DIFF
--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -49,8 +49,8 @@
            (not diff-hl-mode)
            (eq diff-hl-flydiff-modified-tick (buffer-chars-modified-tick))
            (not buffer-file-name)
-           (not (file-exists-p buffer-file-name))
-           (file-remote-p default-directory))
+           (file-remote-p default-directory)
+           (not (file-exists-p buffer-file-name)))
     (diff-hl-update)))
 
 (defun diff-hl-flydiff/modified-p (_state)


### PR DESCRIPTION
It seems that `file-exists-p` can cause Tramp to attempt to reopen a broken connection.  This caused me a problem when I was editing a file via Tramp while `diff-hl-flydiff-mode` was enabled, and the host the file was on became unreachable.  Because the call to `file-remote-p` only occurs _after_ the call to `file-exists-p`, it caused Emacs to become unusable due to messages from Tramp about attempting to reconnect appearing continuously.  This patch fixes this behaviour by switching the order of the last two tests in the `or` form.