### PR TITLE
Allow updating indicators asynchronously (without blocking Emacs)

### DIFF
--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -126,6 +126,32 @@
     (should (looking-at "added"))
     (should-error (diff-hl-next-hunk) :type 'user-error)))
 
+(diff-hl-deftest diff-hl-indirect-buffer-move-with-thread ()
+  (diff-hl-test-in-source
+    (setq diff-hl-update-with-thread t)
+
+    (narrow-to-region (point-min) (point-max))
+    (goto-char (point-min))
+    (kill-whole-line 3)
+    (goto-char (point-max))
+    (insert "added\n")
+    (save-buffer)
+    (diff-hl-mode 1)
+
+    ;; wait for all thread to complete.
+    (dolist (thread (all-threads))
+      (unless (eq thread main-thread)
+        (thread-join thread)))
+
+    (diff-hl-previous-hunk)
+    (should (looking-at "added"))
+    (diff-hl-previous-hunk)
+    (should (looking-at "function2"))
+    (should-error (diff-hl-previous-hunk) :type 'user-error)
+    (diff-hl-next-hunk)
+    (should (looking-at "added"))
+    (should-error (diff-hl-next-hunk) :type 'user-error)))
+
 (diff-hl-deftest diff-hl-can-ignore-staged-changes ()
   (diff-hl-test-in-source
     (goto-char (point-min))

--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -126,31 +126,30 @@
     (should (looking-at "added"))
     (should-error (diff-hl-next-hunk) :type 'user-error)))
 
-(diff-hl-deftest diff-hl-indirect-buffer-move-with-thread ()
+(diff-hl-deftest diff-hl-indirect-buffer-move-async ()
   (diff-hl-test-in-source
-    (setq diff-hl-update-with-thread t)
+   (let ((diff-hl-update-async t))
+     (narrow-to-region (point-min) (point-max))
+     (goto-char (point-min))
+     (kill-whole-line 3)
+     (goto-char (point-max))
+     (insert "added\n")
+     (save-buffer)
+     (diff-hl-mode 1)
 
-    (narrow-to-region (point-min) (point-max))
-    (goto-char (point-min))
-    (kill-whole-line 3)
-    (goto-char (point-max))
-    (insert "added\n")
-    (save-buffer)
-    (diff-hl-mode 1)
+     ;; wait for all thread to complete.
+     (dolist (thread (all-threads))
+       (unless (eq thread main-thread)
+         (thread-join thread)))
 
-    ;; wait for all thread to complete.
-    (dolist (thread (all-threads))
-      (unless (eq thread main-thread)
-        (thread-join thread)))
-
-    (diff-hl-previous-hunk)
-    (should (looking-at "added"))
-    (diff-hl-previous-hunk)
-    (should (looking-at "function2"))
-    (should-error (diff-hl-previous-hunk) :type 'user-error)
-    (diff-hl-next-hunk)
-    (should (looking-at "added"))
-    (should-error (diff-hl-next-hunk) :type 'user-error)))
+     (diff-hl-previous-hunk)
+     (should (looking-at "added"))
+     (diff-hl-previous-hunk)
+     (should (looking-at "function2"))
+     (should-error (diff-hl-previous-hunk) :type 'user-error)
+     (diff-hl-next-hunk)
+     (should (looking-at "added"))
+     (should-error (diff-hl-next-hunk) :type 'user-error))))
 
 (diff-hl-deftest diff-hl-can-ignore-staged-changes ()
   (diff-hl-test-in-source


### PR DESCRIPTION
Problem: On a slow VC backend, `diff-hl-mode` freezes Emacs because `(diff-hl-changes)` takes a long time.

Changes:
- Add a custom variable `diff-hl-update-with-thread`.
- When set to true, update with a separate thread.