### PR TITLE
Make the maximum width of the fringe indicators customizable

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -147,6 +147,10 @@
            (set-default var value)
            (when on (global-diff-hl-mode 1)))))
 
+(defcustom diff-hl-default-width 16
+  "Default width of the bitmap indicators."
+  :type 'integer)
+
 (defcustom diff-hl-highlight-revert-hunk-function
   #'diff-hl-revert-narrow-to-hunk
   "Function to emphasize the current hunk in `diff-hl-revert-hunk'.
@@ -230,8 +234,8 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                    (truncate (* (frame-char-height) spacing))
                  spacing)))
          (w (min (frame-parameter nil (intern (format "%s-fringe" diff-hl-side)))
-                 16))
-         (_ (when (zerop w) (setq w 16)))
+                 diff-hl-default-width))
+         (_ (when (zerop w) (setq w diff-hl-default-width)))
          (middle (make-vector h (expt 2 (1- w))))
          (ones (1- (expt 2 w)))
          (top (copy-sequence middle))

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -147,8 +147,8 @@
            (set-default var value)
            (when on (global-diff-hl-mode 1)))))
 
-(defcustom diff-hl-default-width 16
-  "Default width of the bitmap indicators."
+(defcustom diff-hl-bmp-max-width 16
+  "Maximum width in pixels of the bitmap indicators."
   :type 'integer)
 
 (defcustom diff-hl-highlight-revert-hunk-function
@@ -234,8 +234,8 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                    (truncate (* (frame-char-height) spacing))
                  spacing)))
          (w (min (frame-parameter nil (intern (format "%s-fringe" diff-hl-side)))
-                 diff-hl-default-width))
-         (_ (when (zerop w) (setq w diff-hl-default-width)))
+                 diff-hl-bmp-max-width))
+         (_ (when (zerop w) (setq w diff-hl-bmp-max-width)))
          (middle (make-vector h (expt 2 (1- w))))
          (ones (1- (expt 2 w)))
          (top (copy-sequence middle))


### PR DESCRIPTION
Hi,

Currently, the width of the bitmap indicators is the minimum of the fringe width or 16. 

This makes it a bit inflexible to configure the indicator width. For example, I can't configure the diff-hl indicator width to 1 when the fringe width is 8.

So, in this PR, I made the default width 16 customizable, so that the diff-hl indicator width can be flexibly configured.

Can you consider merging it?

Thanks.