### PR TITLE
Reference revision diff highlights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RM ?= rm -f
 all: compile test
 
 test:
-	$(EMACS) -batch -L . -l test/diff-hl-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -batch -L . -l test/diff-hl-test.el -l test/diff-hl-adjust-test.el -f ert-run-tests-batch-and-exit
 
 compile:
 	$(EMACS) -batch -L . -f batch-byte-compile $(SOURCES)

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -1,4 +1,4 @@
-;; Copyright (C) 2015-2021 Free Software Foundation, Inc. -*- lexical-binding: t -*-
+;; Copyright (C) 2015-2025 Free Software Foundation, Inc. -*- lexical-binding: t -*-
 
 ;; Author:   Jonathan Hayase <PythonNut@gmail.com>
 ;; URL:      https://github.com/dgutov/diff-hl
@@ -40,9 +40,16 @@
 (defvar diff-hl-flydiff-timer nil)
 (make-variable-buffer-local 'diff-hl-flydiff-modified-tick)
 
-(defun diff-hl-flydiff-changes-buffer (file &optional backend)
+(defun diff-hl-flydiff-changes-buffer (file backend &optional new-rev)
   (setq diff-hl-flydiff-modified-tick (buffer-chars-modified-tick))
-  (diff-hl-diff-buffer-with-reference file " *diff-hl-diff*" backend))
+  (if (or new-rev
+          (and
+           (eq backend 'Git)
+           diff-hl-reference-revision
+           (not diff-hl-show-staged-changes)))
+      (diff-hl-with-diff-switches
+       (diff-hl-diff-against-reference file backend " *diff-hl-diff*" new-rev))
+    (diff-hl-diff-buffer-with-reference file " *diff-hl-diff*" backend)))
 
 (defun diff-hl-flydiff-update ()
   (unless (or

--- a/diff-hl-flydiff.el
+++ b/diff-hl-flydiff.el
@@ -42,11 +42,7 @@
 
 (defun diff-hl-flydiff-changes-buffer (file backend &optional new-rev)
   (setq diff-hl-flydiff-modified-tick (buffer-chars-modified-tick))
-  (if (or new-rev
-          (and
-           (eq backend 'Git)
-           diff-hl-reference-revision
-           (not diff-hl-show-staged-changes)))
+  (if new-rev
       (diff-hl-with-diff-switches
        (diff-hl-diff-against-reference file backend " *diff-hl-diff*" new-rev))
     (diff-hl-diff-buffer-with-reference file " *diff-hl-diff*" backend)))

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -701,7 +701,7 @@ Return a list of line overlays used."
               rev2 (cdr revs))))
     (vc-diff-internal t (vc-deduce-fileset) rev1 rev2 t)
     (vc-run-delayed (if (< (line-number-at-pos (point-max)) 3)
-                        (with-current-buffer buffer (diff-hl-remove-overlays))
+                        (with-current-buffer buffer (diff-hl-update))
                       (when (or (not rev2) diff-hl-goto-hunk-old-revisions)
                         (diff-hl-diff-skip-to line))
                       (setq vc-sentinel-movepoint (point))))))

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -417,7 +417,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          (diff-hl-reference-revision
           (or diff-hl-reference-revision
               (and hide-staged
-                   (diff-hl-tip-revision backend)))))
+                   (diff-hl-head-revision backend)))))
     (when backend
       (let ((state (vc-state file backend)))
         (cond
@@ -429,7 +429,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                        (diff-hl-changes-from-buffer
                         (diff-hl-changes-buffer file backend (if hide-staged
                                                                  'git-index
-                                                               (diff-hl-tip-revision backend))))))
+                                                               (diff-hl-head-revision backend))))))
                  (diff-hl-reference-revision nil)
                  (work-changes (diff-hl-changes-from-buffer
                                 (diff-hl-changes-buffer file backend))))
@@ -440,11 +440,11 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          ((eq state 'removed)
           `((1 ,(line-number-at-pos (point-max)) delete))))))))
 
-(defun diff-hl-tip-revision (backend)
-  (if (eq backend 'Git)
-      "HEAD"
-    ;; That seems to cover Hg and Bzr.  Any others?
-    "-1"))
+(defvar diff-hl-head-revision-alist '((Git . "HEAD") (Bzr . "-1") (Hg . ".")))
+
+(defun diff-hl-head-revision (backend)
+  (or (assoc-default backend diff-hl-head-revision-alist)
+      (user-error "VCS not supported for this feature")))
 
 (defun diff-hl-adjust-changes (old new)
   (let ((acc 0)

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -686,12 +686,11 @@ Return a list of line overlays used."
   (when (bound-and-true-p revert-buffer-preserve-modes)
     (diff-hl-update)))
 
-(defun diff-hl-diff-goto-hunk-1 (historic)
+(defun diff-hl-diff-goto-hunk-1 (historic rev1)
   (defvar vc-sentinel-movepoint)
   (vc-buffer-sync)
   (let* ((line (line-number-at-pos))
          (buffer (current-buffer))
-         (rev1 diff-hl-reference-revision)
          rev2)
     (when historic
       (let ((revs (diff-hl-diff-read-revisions rev1)))
@@ -705,10 +704,20 @@ Return a list of line overlays used."
                       (setq vc-sentinel-movepoint (point))))))
 
 (defun diff-hl-diff-goto-hunk (&optional historic)
-  "Run VC diff command and go to the line corresponding to the current."
+  "Run VC diff command and go to the corresponding line in diff.
+With double prefix argument (C-u C-u), the diff is made against the
+reference revision."
   (interactive (list current-prefix-arg))
   (with-current-buffer (or (buffer-base-buffer) (current-buffer))
-    (diff-hl-diff-goto-hunk-1 historic)))
+    (if (equal historic '(16))
+        (diff-hl-diff-reference-goto-hunk)
+      (diff-hl-diff-goto-hunk-1 historic nil))))
+
+(defun diff-hl-diff-reference-goto-hunk ()
+  "Run VC diff command against the reference and go to the corresponding line."
+  (interactive)
+  (with-current-buffer (or (buffer-base-buffer) (current-buffer))
+    (diff-hl-diff-goto-hunk-1 nil diff-hl-reference-revision)))
 
 (defun diff-hl-diff-read-revisions (rev1-default)
   (let* ((file buffer-file-name)

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -376,6 +376,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 (declare-function vc-git-command "vc-git")
 (declare-function vc-git--rev-parse "vc-git")
 (declare-function vc-hg-command "vc-hg")
+(declare-function vc-bzr-command "vc-bzr")
 
 (defun diff-hl-changes-buffer (file backend &optional new-rev)
   (diff-hl-with-diff-switches
@@ -527,7 +528,6 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                                ((zerop inserts) 'delete)
                                (t 'change))))
               (when (eq type 'delete)
-                (setq len 1)
                 (cl-incf line))
               (push (list line inserts deletes type) res)))))
       (nreverse res))))
@@ -574,7 +574,7 @@ Return a list of line overlays used."
         (widen)
         (goto-char (point-min))
         (dolist (c changes)
-          (cl-destructuring-bind (line inserts deletes type) c
+          (cl-destructuring-bind (line inserts _deletes type) c
             (forward-line (- line current-line))
             (setq current-line line)
             (let ((hunk-beg (point))
@@ -641,7 +641,7 @@ Return a list of line overlays used."
   (overlay-put ovl 'before-string (diff-hl-fringe-spec type shape
                                                        diff-hl-side)))
 
-(defun diff-hl-highlight-on-fringe-flat (ovl type shape)
+(defun diff-hl-highlight-on-fringe-flat (ovl type _shape)
   (let ((diff-hl-fringe-bmp-function (lambda (&rest _s) diff-hl-fringe-flat-bmp)))
     (diff-hl-highlight-on-fringe ovl type nil)))
 
@@ -1306,13 +1306,13 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
                      "-i")
       (goto-char (point-min))
       (buffer-substring-no-properties (point) (line-end-position))))
-   (eq backend 'Bzr)
-   (with-temp-buffer
+   ((eq backend 'Bzr)
+    (with-temp-buffer
       (vc-bzr-command (current-buffer) 0 nil
                       "log" "--log-format=template" "--template-str='{revno}'"
                       "-r" diff-hl-reference-revision)
       (goto-char (point-min))
-      (buffer-substring-no-properties (point) (line-end-position)))
+      (buffer-substring-no-properties (point) (line-end-position))))
    (t
     diff-hl-reference-revision)))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -527,6 +527,9 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                    (type (cond ((zerop deletes) 'insert)
                                ((zerop inserts) 'delete)
                                (t 'change))))
+              (when (eq type 'delete)
+                (setq len 1)
+                (cl-incf line))
               (push (list line inserts deletes type) res)))))
       (nreverse res))))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -96,6 +96,21 @@
   "Face used to highlight changed lines."
   :group 'diff-hl)
 
+(defface diff-hl-reference-insert
+  '((default :inherit diff-hl-insert))
+  "Face used to highlight lines inserted since reference rev."
+  :group 'diff-hl)
+
+(defface diff-hl-reference-delete
+  '((default :inherit diff-hl-delete))
+  "Face used to highlight lines deleted since reference rev."
+  :group 'diff-hl)
+
+(defface diff-hl-reference-change
+  '((default :inherit diff-hl-change))
+  "Face used to highlight lines changed since reference rev."
+  :group 'diff-hl)
+
 (defcustom diff-hl-command-prefix (kbd "C-x v")
   "The prefix for all `diff-hl' commands."
   :group 'diff-hl
@@ -146,6 +161,12 @@ built-in bitmaps."
 (defcustom diff-hl-fringe-face-function 'diff-hl-fringe-face-from-type
   "Function to choose the fringe face for a given change type
   and position within a hunk.  Should accept two arguments."
+  :group 'diff-hl
+  :type 'function)
+
+(defcustom diff-hl-fringe-reference-face-function 'diff-hl-fringe-reference-face-from-type
+  "Function to choose the fringe face for a given change type
+and position within a \"diff to reference\" hunk."
   :group 'diff-hl
   :type 'function)
 
@@ -308,6 +329,9 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 
 (defun diff-hl-fringe-face-from-type (type _pos)
   (intern (format "diff-hl-%s" type)))
+
+(defun diff-hl-fringe-reference-face-from-type (type _pos)
+  (intern (format "diff-hl-reference-%s" type)))
 
 (defun diff-hl-fringe-bmp-from-pos (_type pos)
   (intern (format "diff-hl-bmp-%s" pos)))
@@ -557,7 +581,9 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          (changes (assoc-default :current cc nil cc)))
     (diff-hl-remove-overlays)
     (let ((diff-hl-highlight-function
-           diff-hl-highlight-reference-function))
+           diff-hl-highlight-reference-function)
+          (diff-hl-fringe-face-function
+           diff-hl-fringe-reference-face-function))
       (diff-hl--update-overlays ref-changes))
     (diff-hl--update-overlays changes)))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -431,7 +431,8 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
            diff-hl-reference-revision
            (diff-hl-modified-p state))
           (let* ((ref-changes
-                  (and diff-hl-reference-revision
+                  (and (or diff-hl-reference-revision
+                           hide-staged)
                        (diff-hl-changes-from-buffer
                         (diff-hl-changes-buffer file backend (if hide-staged
                                                                  'git-index

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -382,9 +382,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
    (diff-hl-diff-against-reference file backend " *diff-hl* " new-rev)))
 
 (defun diff-hl-diff-against-reference (file backend buffer &optional new-rev)
-  (if (and (eq backend 'Git)
-           (not new-rev)
-           (not diff-hl-show-staged-changes))
+  (if (eq new-rev 'git-index)
       (if diff-hl-reference-revision
           (apply #'vc-git-command buffer 1
                  (list file)
@@ -429,7 +427,8 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
           (let* ((ref-changes
                   (and diff-hl-reference-revision
                        (diff-hl-changes-from-buffer
-                        (diff-hl-changes-buffer file backend (unless hide-staged
+                        (diff-hl-changes-buffer file backend (if hide-staged
+                                                                 'git-index
                                                                (diff-hl-tip-revision backend))))))
                  (diff-hl-reference-revision nil)
                  (work-changes (diff-hl-changes-from-buffer

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -440,7 +440,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          ((eq state 'removed)
           `((1 ,(line-number-at-pos (point-max)) delete))))))))
 
-(defvar diff-hl-head-revision-alist '((Git . "HEAD") (Bzr . "-1") (Hg . ".")))
+(defvar diff-hl-head-revision-alist '((Git . "HEAD") (Bzr . "last:1") (Hg . ".")))
 
 (defun diff-hl-head-revision (backend)
   (or (assoc-default backend diff-hl-head-revision-alist)
@@ -1306,6 +1306,13 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
                      "-i")
       (goto-char (point-min))
       (buffer-substring-no-properties (point) (line-end-position))))
+   (eq backend 'Bzr)
+   (with-temp-buffer
+      (vc-bzr-command (current-buffer) 0 nil
+                      "log" "--log-format=template" "--template-str='{revno}'"
+                      "-r" diff-hl-reference-revision)
+      (goto-char (point-min))
+      (buffer-substring-no-properties (point) (line-end-position)))
    (t
     diff-hl-reference-revision)))
 

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -452,6 +452,10 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
       (vc-working-revision buffer-file-name backend)))
 
 (defun diff-hl-adjust-changes (old new)
+  "Adjust changesets in OLD using changes in NEW.
+The result alters the values inside the OLD changeset so that the line
+numbers and insertion/deletion counts refer to the lines in the file
+contents as they are (or would be) after applying the changes in NEW."
   (let ((acc 0)
         (ref old)
         overlap)

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -220,7 +220,10 @@ performance when viewing such files in certain conditions."
 
 (defcustom diff-hl-show-staged-changes t
   "Whether to include staged changes in the indicators.
-Only affects Git, it's the only backend that has staging area."
+Only affects Git, it's the only backend that has staging area.
+
+When `diff-hl-highlight-reference-function' is non-nil, instead of being
+hidden, the staged changes become part of the \"reference\" indicators."
   :type 'boolean)
 
 (defcustom diff-hl-goto-hunk-old-revisions nil

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -953,7 +953,8 @@ Only supported with Git."
     (with-current-buffer dest-buffer
       (let ((inhibit-read-only t))
         (erase-buffer)))
-    (diff-hl-diff-buffer-with-reference file dest-buffer nil 3)
+    (let (diff-hl-reference-revision)
+      (diff-hl-diff-buffer-with-reference file dest-buffer nil 3))
     (with-current-buffer dest-buffer
       (with-no-warnings
         (let (diff-auto-refine-mode)
@@ -1024,7 +1025,8 @@ Pops up a diff buffer that can be edited to choose the changes to stage."
     (with-current-buffer dest-buffer
       (let ((inhibit-read-only t))
         (erase-buffer)))
-    (diff-hl-diff-buffer-with-reference file dest-buffer nil 3)
+    (let (diff-hl-reference-revision)
+      (diff-hl-diff-buffer-with-reference file dest-buffer nil 3))
     (with-current-buffer dest-buffer
       (let ((inhibit-read-only t))
         (when end

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -445,7 +445,9 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 
 (defun diff-hl-head-revision (backend)
   (or (assoc-default backend diff-hl-head-revision-alist)
-      (user-error "VCS not supported for this feature")))
+      ;; It's usually cached already (e.g. for mode-line).
+      ;; So this is basically an optimization for rare cases.
+      (vc-working-revision buffer-file-name backend)))
 
 (defun diff-hl-adjust-changes (old new)
   (let ((acc 0)

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -434,7 +434,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                  (work-changes (diff-hl-changes-from-buffer
                                 (diff-hl-changes-buffer file backend))))
             `((:reference . ,(diff-hl-adjust-changes ref-changes work-changes))
-              (:current . ,work-changes))))
+              (:working . ,work-changes))))
          ((eq state 'added)
           `((1 ,(line-number-at-pos (point-max)) insert)))
          ((eq state 'removed)
@@ -612,7 +612,7 @@ Return a list of line overlays used."
 (defun diff-hl--update ()
   (let* ((cc (diff-hl-changes))
          (ref-changes (assoc-default :reference cc))
-         (changes (assoc-default :current cc nil cc))
+         (changes (assoc-default :working cc nil cc))
          reuse)
     (diff-hl-remove-overlays)
     (let ((diff-hl-highlight-function

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -416,7 +416,8 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
           (let* ((ref-changes
                   (and diff-hl-reference-revision
                        (diff-hl-changes-from-buffer
-                        (diff-hl-changes-buffer file backend "HEAD"))))
+                        (diff-hl-changes-buffer file backend
+                                                (diff-hl-tip-revision backend)))))
                  (diff-hl-reference-revision nil)
                  (work-changes (diff-hl-changes-from-buffer
                                 (diff-hl-changes-buffer file backend))))
@@ -426,6 +427,12 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
           `((1 ,(line-number-at-pos (point-max)) insert)))
          ((eq state 'removed)
           `((1 ,(line-number-at-pos (point-max)) delete))))))))
+
+(defun diff-hl-tip-revision (backend)
+  (if (eq backend 'Git)
+      "HEAD"
+    ;; That seems to cover Hg and Bzr.  Any others?
+    "-1"))
 
 (defun diff-hl-adjust-changes (old new)
   (let ((acc 0)

--- a/test/diff-hl-adjust-test.el
+++ b/test/diff-hl-adjust-test.el
@@ -1,0 +1,69 @@
+;;; diff-hl-adjust-test.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'diff-hl)
+(require 'ert)
+
+(ert-deftest diff-hl-adjust-no-intersection ()
+  (should
+   (equal
+    (diff-hl-adjust-changes
+     (copy-tree '((1 2 0) (5 3 0)))
+     (list '(3 4 2) '(11 3 0)))
+    '((1 2 0) (7 3 0)))))
+
+(ert-deftest diff-hl-adjust-overlap-front ()
+  (should
+   (equal
+    (diff-hl-adjust-changes
+     (copy-tree '((1 2 0) (5 3 0) (11 0 2)))
+     (list '(3 6 4)))
+    '((1 2 0) (9 1 0) (13 0 2)))))
+
+(ert-deftest diff-hl-adjust-overlap-back ()
+  (should
+   (equal
+    (diff-hl-adjust-changes
+     (copy-tree '((1 2 0) (11 0 2)))
+     (list '(2 6 4)))
+    '((1 4 0) (13 0 2)))))
+
+(ert-deftest diff-hl-adjust-overlap-multiple ()
+  (should
+   (equal
+    (diff-hl-adjust-changes
+     (copy-tree '((1 2 0) (4 3 2)))
+     (list '(2 6 4)))
+    '((1 4 0) (8 1 2)))))
+
+(ert-deftest diff-hl-adjust-multiple-new ()
+  (should
+   (equal
+    (diff-hl-adjust-changes
+     (copy-tree '((1 2 0) (5 3 0)))
+     (list '(2 1 0) '(4 2 1)))
+    '((1 3 0) (7 3 0)))))
+
+(provide 'diff-hl-adjust-test)
+
+;;; diff-hl-adjust-test.el ends here

--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -164,12 +164,16 @@
     (let ((diff-hl-show-staged-changes t))
       (should
        (equal (diff-hl-changes)
-              '((1 1 insert)
-                (12 1 insert)))))
+              '((:reference . nil)
+                (:working
+                 .
+                 ((1 1 0 insert)
+                  (12 1 0 insert)))))))
     (let ((diff-hl-show-staged-changes nil))
       (should
        (equal (diff-hl-changes)
-              '((12 1 insert)))))))
+              '((:reference . ((1 1 0 insert)))
+                (:working . ((12 1 0 insert)))))))))
 
 (diff-hl-deftest diff-hl-flydiff-can-ignore-staged-changes ()
   (diff-hl-test-in-source
@@ -183,13 +187,13 @@
       (should
        (equal (diff-hl-changes-from-buffer
                (diff-hl-diff-buffer-with-reference buffer-file-name))
-              '((1 1 insert)
-                (12 1 insert)))))
+              '((1 1 0 insert)
+                (12 1 0 insert)))))
     (let ((diff-hl-show-staged-changes nil))
       (should
        (equal (diff-hl-changes-from-buffer
                (diff-hl-diff-buffer-with-reference buffer-file-name))
-              '((12 1 insert)))))))
+              '((12 1 0 insert)))))))
 
 (diff-hl-deftest diff-hl-can-split-away-no-trailing-newline ()
   (diff-hl-test-in-source


### PR DESCRIPTION
This splits highlighting into two groups: diff between the buffer contents and HEAD (or staging area (*)), and diff between the latter and `diff-hl-reference-revision` (if set). Looks like this:

![diff-hl-references-highlights](https://github.com/user-attachments/assets/ecce65e3-8b8e-4ba0-adcc-05121c75e281)

The new indicators use a specific bitmap and new faces, both of which can be customized. The default bitmap is an empty one, so on the screenshot it's the lines without the "border".

A new fn option is added as well: `diff-hl-highlight-reference-function`. For more advanced customization.

(*) This change also uses the new indicators for the staged changes (Git only, naturally) when `diff-hl-show-staged-changes` is customized to nil. In a way that conflates those pieces of data, but I expect that most users will either use one or the other, and the behavior still makes sense when combined.