### PR TITLE
Delete temporary file after use

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1141,6 +1141,7 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
            (switches (format "-U %d --strip-trailing-cr" (or context-lines 0))))
       (diff-no-select rev (current-buffer) switches 'noasync
                       (get-buffer-create dest-buffer))
+      (delete-file rev)
       (with-current-buffer dest-buffer
         (let ((inhibit-read-only t))
           ;; Function `diff-sentinel' adds a final line, so remove it


### PR DESCRIPTION
I noticed that my `/dev/shm` contains lots of temporary files left by diff-hl. Unless I'm missing something, `rev` in `diff-hl-diff-buffer-with-reference` is always a filename created by `diff-hl-make-temp-file-name`, so delete it after use.