### PR TITLE
Provide diff switches for jj

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -308,6 +308,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 
 (defvar vc-svn-diff-switches)
 (defvar vc-fossil-diff-switches)
+(defvar vc-jj-diff-switches)
 
 (defmacro diff-hl-with-diff-switches (body)
   `(let ((vc-git-diff-switches
@@ -323,6 +324,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          (vc-hg-diff-switches nil)
          (vc-svn-diff-switches nil)
          (vc-fossil-diff-switches '("-c" "0"))
+         (vc-jj-diff-switches '("--context=0"))
          (vc-diff-switches '("-U0"))
          ,@(when (boundp 'vc-disable-async-diff)
              '((vc-disable-async-diff t))))


### PR DESCRIPTION
Note that for those specific switches, they are added on top of the original ones as `vc-jj` already sets `vc-jj-diff-switches` to non-nil (the value is `("--git")` by default to be specific).