### PR TITLE
Some polish for `diff-hl-show-hunk`

### DIFF
--- a/diff-hl-inline-popup.el
+++ b/diff-hl-inline-popup.el
@@ -154,7 +154,8 @@ FOOTER are showed at start and end."
                  diff-hl-inline-popup--current-footer)))
       ;; https://debbugs.gnu.org/38563, `company--replacement-string'.
       (add-face-text-property 0 (length str) 'default t str)
-      (overlay-put diff-hl-inline-popup--current-popup 'after-string str))))
+      (put-text-property 0 1 'cursor 0 str)
+      (overlay-put diff-hl-inline-popup--current-popup 'before-string str))))
 
 (defun diff-hl-inline-popup--popup-down()
   "Scrolls one line down."

--- a/diff-hl-show-hunk-posframe.el
+++ b/diff-hl-show-hunk-posframe.el
@@ -202,7 +202,6 @@ The button calls an ACTION."
                     :internal-border-color diff-hl-show-hunk-posframe-internal-border-color
                     :hidehandler nil
                     ;; Sometimes, header-line is not taken into account, so put a min height and a min width
-                    :min-height (when diff-hl-show-hunk-posframe-show-header-line 10)
                     :min-width (when diff-hl-show-hunk-posframe-show-header-line
                                  (length (diff-hl-show-hunk-posframe--header-line)))
                     :respect-header-line diff-hl-show-hunk-posframe-show-header-line

--- a/diff-hl-show-hunk-posframe.el
+++ b/diff-hl-show-hunk-posframe.el
@@ -194,8 +194,12 @@ The button calls an ACTION."
   (setq posframe-mouse-banish nil)
   (setq diff-hl-show-hunk--original-frame (selected-frame))
 
-  (let* ((hunk-overlay diff-hl-show-hunk--original-overlay)
-         (position (overlay-end hunk-overlay)))
+  (let* ((overlay diff-hl-show-hunk--original-overlay)
+         (type (overlay-get overlay 'diff-hl-hunk-type))
+         (position (save-excursion
+                     (goto-char (overlay-end overlay))
+                     (forward-line -1)
+                     (point))))
     (setq
      diff-hl-show-hunk--frame
      (posframe-show buffer
@@ -213,6 +217,7 @@ The button calls an ACTION."
                     :respect-header-line diff-hl-show-hunk-posframe-show-header-line
                     :respect-tab-line nil
                     :respect-mode-line nil
+                    :y-pixel-offset (if (eq type 'delete) (- (default-line-height)))
                     :override-parameters diff-hl-show-hunk-posframe-parameters)))
 
   (set-frame-parameter diff-hl-show-hunk--frame 'drag-internal-border t)

--- a/diff-hl-show-hunk-posframe.el
+++ b/diff-hl-show-hunk-posframe.el
@@ -76,15 +76,7 @@ Customize it to change the base properties of the text.")
   (interactive)
   (diff-hl-show-hunk-posframe--transient-mode -1)
   (when (frame-live-p diff-hl-show-hunk--frame)
-    (make-frame-invisible diff-hl-show-hunk--frame))
-  (when diff-hl-show-hunk--original-frame
-    (when (frame-live-p diff-hl-show-hunk--original-frame)
-      (let ((frame diff-hl-show-hunk--original-frame))
-        (select-frame-set-input-focus frame)
-        ;; In Gnome, sometimes the input focus is not restored to the
-        ;; original frame, so we try harder in a while
-        (run-with-timer 0.1 nil (lambda () (select-frame-set-input-focus frame)))))
-    (setq diff-hl-show-hunk--original-frame nil)))
+    (make-frame-invisible diff-hl-show-hunk--frame)))
 
 (defvar diff-hl-show-hunk-posframe--transient-mode-map
   (let ((map (make-sparse-keymap)))

--- a/diff-hl-show-hunk-posframe.el
+++ b/diff-hl-show-hunk-posframe.el
@@ -171,7 +171,6 @@ The button calls an ACTION."
     (user-error
      "Package `posframe' is not workable.  Please customize diff-hl-show-hunk-function"))
 
-  (diff-hl-show-hunk--posframe-hide)
   (setq diff-hl-show-hunk--hide-function #'diff-hl-show-hunk--posframe-hide)
 
   ;; put an overlay to override read-only-mode keymap
@@ -228,8 +227,7 @@ The button calls an ACTION."
       (setq cursor-type 'box)
 
       ;; Recenter around point
-      (recenter)))
-  (select-frame-set-input-focus diff-hl-show-hunk--frame))
+      (recenter))))
 
 (provide 'diff-hl-show-hunk-posframe)
 ;;; diff-hl-show-hunk-posframe.el ends here

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -338,7 +338,8 @@ end of the OVERLAY, so posframe/inline is placed below the hunk."
         (set-window-start nil (point)))
        ((> (point) pt)
         (redisplay))))
-    (goto-char (1- (overlay-end overlay)))))
+    (goto-char (1- (overlay-end overlay)))
+    (forward-line 0)))
 
 ;;;###autoload
 (defun diff-hl-show-hunk-next ()
@@ -360,10 +361,6 @@ end of the OVERLAY, so posframe/inline is placed below the hunk."
   "Show the VC diff hunk at point.
 The backend is determined by `diff-hl-show-hunk-function'."
   (interactive)
-
-  ;; Close any previous hunk
-  (save-excursion
-    (diff-hl-show-hunk-hide))
 
   (unless (vc-backend buffer-file-name)
     (user-error "The buffer is not under version control"))


### PR DESCRIPTION
Hi @alvarogonzalezsotillo, please check this out if you have the time and you're still using the features.

I made a pass at the code to make the rendering backends more similar in behavior (wrt positioning), and less "blinky" with the posframe backend.

It removes a couple of workarounds which mention Gnome but I couldn't reproduce (with version 46 anyway) - to fix the side-effects, which both had. Would be great if you could test and see if those were still necessary.