### PR TITLE
Fix `diff-hl-resolved-reference-revision` for Hg and Bzr with buffer-local `diff-hl-reference-revision`

### DIFF
--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -223,6 +223,21 @@
 Diff finished."
                  (buffer-substring (point) (point-max))))))))
 
+(diff-hl-deftest diff-hl-resolved-reference-revision-buffer-local-hg ()
+  (diff-hl-test-in-source
+   (setq-local diff-hl-reference-revision "test-rev")
+   (setq-local vc-hg-program "chg")
+   (condition-case err
+       (progn
+         (diff-hl-resolved-reference-revision 'Hg)
+         (ert-fail "Expected an error to be signaled but none was."))
+     ;; We don't have a hg repo, but we can use the error message to verify the
+     ;; underlying command.
+     (error
+      (should (string-match-p
+               "chg .*identify -r test-rev -i"
+               (error-message-string err)))))))
+
 (provide 'diff-hl-test)
 
 ;;; diff-hl-test.el ends here


### PR DESCRIPTION
**Problem**:
`diff-hl-resolved-reference-revision` fails to work correctly when `diff-hl-reference-revision` is set as a buffer-local variable.

Example:
```emacs-lisp
(setq-local diff-hl-reference-revision "test-rev")
```

**Cause**:
When the implementation for backends like Hg (and similarly Bzr) uses `with-temp-buffer`, buffer-local variables from the original buffer context are not accessible. Consequently, `diff-hl-reference-revision` evaluates to `nil` within the temporary buffer.

For 'Hg as an exmaple,
```emacs-lisp
(with-temp-buffer
  (vc-hg-command (current-buffer) 0 nil
                 "identify" "-r" diff-hl-reference-revision
                 "-i")
  ...)
```

This leads to an incorrect command being executed:
*   **Expected hg command**: `hg identify -r test-rev -i`
*   **Actual hg command**: `hg identify -r -i`

**Fix**:
To resolve this, the value of `diff-hl-reference-revision` is now copied into a non-buffer-local variable (e.g., `original-diff-hl-reference-revision`) *before* entering the `with-temp-buffer` block. This non-buffer-local variable is then used within the temporary buffer context, ensuring the correct revision is always passed to the underlying version control command.

**Tests**:
I have tested it in my hg repo. Also added a test in `diff-hl-test.el`.