### PR TITLE
fix(diff-hl.el): Silence compiler warnings

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -69,6 +69,9 @@
   (require 'vc-git)
   (require 'vc-hg)
   (require 'face-remap)
+  (declare-function project-buffers 'project)
+  (declare-function project-name 'project)
+  (declare-function project-roots 'project)
   (declare-function smartrep-define-key 'smartrep))
 
 (defgroup diff-hl nil


### PR DESCRIPTION
Fix compiler warnings:

diff-hl.el:1677:19: Warning: the function ‘project-buffers’ is not known to be defined.
diff-hl.el:1668:9: Warning: the function ‘project-roots’ is not known to be defined.
diff-hl.el:1654:17: Warning: the function ‘project-name’ is not known to be defined.