### PR TITLE
Add Ediff support

### DIFF
--- a/diff-hl-show-hunk-inline.el
+++ b/diff-hl-show-hunk-inline.el
@@ -361,7 +361,7 @@ BUFFER is a buffer with the hunk."
              (when smart-lines
                (when (not (eq 0 original-lines-number))
                  original-lines-number)))
-            (footer "(q)Quit  (p)Previous  (n)Next  (r)Revert  (c)Copy original"))
+            (footer "(q)Quit  (p)Previous  (n)Next  (e)Ediff  (r)Revert  (c)Copy original"))
         (unless diff-hl-show-staged-changes
           (setq footer (concat footer " (S)Stage")))
         (diff-hl-show-hunk-inline-show

--- a/diff-hl-show-hunk-posframe.el
+++ b/diff-hl-show-hunk-posframe.el
@@ -146,6 +146,11 @@ The button calls an ACTION."
     #'diff-hl-show-hunk-copy-original-text)
 
    (diff-hl-show-hunk--posframe-button
+    "⇄ Ediff"
+    "Ediff (\\[diff-hl-show-hunk-ediff])"
+    #'diff-hl-show-hunk-ediff)
+
+   (diff-hl-show-hunk--posframe-button
     "♻ Revert hunk"
     "Revert hunk (\\[diff-hl-show-hunk-revert-hunk])"
     #'diff-hl-show-hunk-revert-hunk)

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -219,6 +219,7 @@ Returns a list with the buffer and the line number of the clicked line."
     (define-key map (kbd "p") #'diff-hl-show-hunk-previous)
     (define-key map (kbd "n") #'diff-hl-show-hunk-next)
     (define-key map (kbd "c") #'diff-hl-show-hunk-copy-original-text)
+    (define-key map (kbd "e") #'diff-hl-show-hunk-ediff)
     (define-key map (kbd "r") #'diff-hl-show-hunk-revert-hunk)
     (define-key map (kbd "[") #'diff-hl-show-hunk-previous)
     (define-key map (kbd "]") #'diff-hl-show-hunk-next)
@@ -245,6 +246,12 @@ Returns a list with the buffer and the line number of the clicked line."
   (interactive)
   (diff-hl-show-hunk-hide)
   (diff-hl-stage-current-hunk))
+
+(defun diff-hl-show-hunk-ediff ()
+  "Dismiss the popup and run Ediff for the current hunk."
+  (interactive)
+  (diff-hl-show-hunk-hide)
+  (diff-hl-ediff-current-hunk))
 
 ;;;###autoload
 (defun diff-hl-show-hunk-previous ()

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -220,6 +220,7 @@ Returns a list with the buffer and the line number of the clicked line."
     (define-key map (kbd "p") #'diff-hl-show-hunk-previous)
     (define-key map (kbd "n") #'diff-hl-show-hunk-next)
     (define-key map (kbd "c") #'diff-hl-show-hunk-copy-original-text)
+    (define-key map (kbd "e") #'diff-hl-show-hunk-ediff)
     (define-key map (kbd "r") #'diff-hl-show-hunk-revert-hunk)
     (define-key map (kbd "[") #'diff-hl-show-hunk-previous)
     (define-key map (kbd "]") #'diff-hl-show-hunk-next)
@@ -246,6 +247,12 @@ Returns a list with the buffer and the line number of the clicked line."
   (interactive)
   (diff-hl-show-hunk-hide)
   (diff-hl-stage-current-hunk))
+
+(defun diff-hl-show-hunk-ediff ()
+  "Dismiss the popup and run Ediff for the current hunk."
+  (interactive)
+  (diff-hl-show-hunk-hide)
+  (diff-hl-ediff-current-hunk))
 
 ;;;###autoload
 (defun diff-hl-show-hunk-previous ()

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -36,6 +36,7 @@
 ;; `diff-hl-previous-hunk'   C-x v [
 ;; `diff-hl-next-hunk'       C-x v ]
 ;; `diff-hl-show-hunk'       C-x v *
+;; `diff-hl-ediff-current-hunk' C-x v e
 ;; `diff-hl-stage-current-hunk' C-x v S
 ;; `diff-hl-set-reference-rev'
 ;; `diff-hl-reset-reference-rev'
@@ -435,6 +436,17 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 (declare-function vc-git--rev-parse "vc-git")
 (declare-function vc-hg-command "vc-hg")
 (declare-function vc-bzr-command "vc-bzr")
+(declare-function vc-find-revision-no-save "vc")
+(declare-function ediff-buffers "ediff")
+(declare-function ediff-diff-at-point "ediff-util")
+(declare-function ediff-jump-to-difference "ediff-util")
+(defvar ediff-number-of-differences)
+
+(defun diff-hl--use-git-index-base-p (backend)
+  "Whether diff-hl should use the Git index as the reference base."
+  (and (eq backend 'Git)
+       (not diff-hl-reference-revision)
+       (not diff-hl-show-staged-changes)))
 
 (defun diff-hl-changes-buffer (file backend &optional new-rev bufname)
   (diff-hl-with-diff-switches
@@ -443,9 +455,7 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
 (defun diff-hl-diff-against-reference (file backend buffer &optional new-rev)
   (cond
    ((and (not new-rev)
-         (not diff-hl-reference-revision)
-         (not diff-hl-show-staged-changes)
-         (eq backend 'Git))
+         (diff-hl--use-git-index-base-p backend))
     (apply #'vc-git-command buffer
            (if (diff-hl--use-async-p) 'async 1)
            (list file)
@@ -903,6 +913,54 @@ buffer will show the position corresponding to its current line."
                           (diff-hl-diff-skip-to line relname)
                           (setq vc-sentinel-movepoint (point))))))))
 
+(defun diff-hl--ediff-reference-buffer (file)
+  "Return the reference buffer for FILE used in Ediff."
+  (unless file
+    (user-error "No current file"))
+  (let ((backend (vc-backend file)))
+    (unless backend
+      (user-error "The buffer is not under version control"))
+    (let* ((reference diff-hl-reference-revision)
+           ;; Use the index snapshot only when diff-hl hides staged changes.
+           (use-index (and (diff-hl--use-git-index-base-p backend)
+                           (not diff-hl-highlight-reference-function)))
+           (buf
+            (if use-index
+                (let ((obj (diff-hl-git-index-object-name file)))
+                  (unless obj
+                    (user-error "No index entry for %s" file))
+                  (let ((filename (diff-hl-git-index-revision file obj)))
+                    (find-file-noselect filename)))
+              (let ((rev (or reference
+                             (assoc-default backend diff-hl-head-revision-alist)
+                             (diff-hl-working-revision file backend))))
+                (unless rev
+                  (user-error "No reference revision specified"))
+                (setq rev (diff-hl-resolved-revision backend rev))
+                (vc-find-revision-no-save file rev backend)))))
+      (with-current-buffer buf
+        (set-buffer-modified-p nil)
+        (read-only-mode 1))
+      buf)))
+
+;;;###autoload
+(defun diff-hl-ediff-current-hunk ()
+  "Run Ediff against current comparison base.  Jump to hunk at point."
+  (interactive)
+  (require 'ediff)
+  (let* ((pos (point))
+         (file (or buffer-file-name
+                   (and-let* ((base (buffer-base-buffer)))
+                     (buffer-file-name base))))
+         (refbuf (diff-hl--ediff-reference-buffer file))
+         (startup
+          (list
+           (lambda ()
+             (unless (zerop ediff-number-of-differences)
+               (ediff-jump-to-difference
+                (max 1 (ediff-diff-at-point 'B pos))))))))
+    (ediff-buffers refbuf (current-buffer) startup 'diff-hl-ediff)))
+
 (defun diff-hl-diff-read-revisions (rev1-default)
   (let* ((file buffer-file-name)
          (files (list file))
@@ -1304,6 +1362,7 @@ Pops up a diff buffer that can be edited to choose the changes to stage."
     (define-key map "[" 'diff-hl-previous-hunk)
     (define-key map "]" 'diff-hl-next-hunk)
     (define-key map "*" 'diff-hl-show-hunk)
+    (define-key map "e" 'diff-hl-ediff-current-hunk)
     (define-key map "{" 'diff-hl-show-hunk-previous)
     (define-key map "}" 'diff-hl-show-hunk-next)
     (define-key map "S" 'diff-hl-stage-dwim)
@@ -1376,7 +1435,8 @@ The value of this variable is a mode line template as in
 
 (defvar diff-hl-repeat-exceptions '(diff-hl-show-hunk
                                     diff-hl-show-hunk-previous
-                                    diff-hl-show-hunk-next))
+                                    diff-hl-show-hunk-next
+                                    diff-hl-ediff-current-hunk))
 
 (when (require 'smartrep nil t)
   (declare-function smartrep-define-key 'smartrep)
@@ -1516,9 +1576,7 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
            (backend (or backend (vc-backend file)))
            (temporary-file-directory diff-hl-temporary-directory)
            (rev
-            (if (and (eq backend 'Git)
-                     (not diff-hl-reference-revision)
-                     (not diff-hl-show-staged-changes))
+            (if (diff-hl--use-git-index-base-p backend)
                 (diff-hl-git-index-revision
                  file
                  (diff-hl-git-index-object-name file))

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -450,6 +450,17 @@ BUFFER defaults to the current buffer."
 (declare-function vc-git--rev-parse "vc-git")
 (declare-function vc-hg-command "vc-hg")
 (declare-function vc-bzr-command "vc-bzr")
+(declare-function vc-find-revision-no-save "vc")
+(declare-function ediff-buffers "ediff")
+(declare-function ediff-diff-at-point "ediff-util")
+(declare-function ediff-jump-to-difference "ediff-util")
+(defvar ediff-number-of-differences)
+
+(defun diff-hl--use-git-index-base-p (backend)
+  "Whether diff-hl should use the Git index as the reference base."
+  (and (eq backend 'Git)
+       (not diff-hl-reference-revision)
+       (not diff-hl-show-staged-changes)))
 
 (defun diff-hl-changes-buffer (file backend &optional new-rev bufname)
   (diff-hl-with-diff-switches
@@ -458,9 +469,7 @@ BUFFER defaults to the current buffer."
 (defun diff-hl-diff-against-reference (file backend buffer &optional new-rev)
   (cond
    ((and (not new-rev)
-         (not diff-hl-reference-revision)
-         (not diff-hl-show-staged-changes)
-         (eq backend 'Git))
+         (diff-hl--use-git-index-base-p backend))
     (apply #'vc-git-command buffer
            (if (diff-hl--use-async-p) 'async 1)
            (list file)
@@ -921,6 +930,54 @@ buffer will show the position corresponding to its current line."
         (vc-run-delayed (when relname
                           (diff-hl-diff-skip-to line relname)
                           (setq vc-sentinel-movepoint (point))))))))
+
+(defun diff-hl--ediff-reference-buffer (file)
+  "Return the reference buffer for FILE used in Ediff."
+  (unless file
+    (user-error "No current file"))
+  (let ((backend (vc-backend file)))
+    (unless backend
+      (user-error "The buffer is not under version control"))
+    (let* ((reference diff-hl-reference-revision)
+           ;; Use the index snapshot only when diff-hl hides staged changes.
+           (use-index (and (diff-hl--use-git-index-base-p backend)
+                           (not diff-hl-highlight-reference-function)))
+           (buf
+            (if use-index
+                (let ((obj (diff-hl-git-index-object-name file)))
+                  (unless obj
+                    (user-error "No index entry for %s" file))
+                  (let ((filename (diff-hl-git-index-revision file obj)))
+                    (find-file-noselect filename)))
+              (let ((rev (or reference
+                             (assoc-default backend diff-hl-head-revision-alist)
+                             (diff-hl-working-revision file backend))))
+                (unless rev
+                  (user-error "No reference revision specified"))
+                (setq rev (diff-hl-resolved-revision backend rev))
+                (vc-find-revision-no-save file rev backend)))))
+      (with-current-buffer buf
+        (set-buffer-modified-p nil)
+        (read-only-mode 1))
+      buf)))
+
+;;;###autoload
+(defun diff-hl-ediff-current-hunk ()
+  "Run Ediff against current comparison base.  Jump to hunk at point."
+  (interactive)
+  (require 'ediff)
+  (let* ((pos (point))
+         (file (or buffer-file-name
+                   (and-let* ((base (buffer-base-buffer)))
+                     (buffer-file-name base))))
+         (refbuf (diff-hl--ediff-reference-buffer file))
+         (startup
+          (list
+           (lambda ()
+             (unless (zerop ediff-number-of-differences)
+               (ediff-jump-to-difference
+                (max 1 (ediff-diff-at-point 'B pos))))))))
+    (ediff-buffers refbuf (current-buffer) startup)))
 
 (defun diff-hl-diff-read-revisions (rev1-default)
   (let* ((file (diff-hl--buffer-file-name))
@@ -1541,9 +1598,7 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
            (temporary-file-directory diff-hl-temporary-directory)
            (enable-local-variables nil)
            (rev
-            (if (and (eq backend 'Git)
-                     (not diff-hl-reference-revision)
-                     (not diff-hl-show-staged-changes))
+            (if (diff-hl--use-git-index-base-p backend)
                 (diff-hl-git-index-revision
                  file
                  (diff-hl-git-index-object-name file))


### PR DESCRIPTION
Add the command 'diff-hl-ediff-current-hunk', bound to 'C-x v e' in
'diff-hl-mode-map' and 'e' in the show-hunk UI, that uses Ediff to compare
against the reference revision, jumping to the hunk nearest point.

* diff-hl.el (diff-hl--use-git-index-base-p): New helper function.
(diff-hl-diff-against-reference, diff-hl-diff-buffer-with-reference): Use it.
(diff-hl--ediff-reference-buffer): New helper function.
(diff-hl-ediff-current-hunk): New command.
(diff-hl-command-map): Bind 'e' to 'diff-hl-ediff-current-hunk'.
(diff-hl-repeat-exceptions): Add 'diff-hl-ediff-current-hunk'.

* diff-hl-show-hunk.el (diff-hl-show-hunk-ediff): New command.
(diff-hl-show-hunk-map): Bind it to 'e'.

* diff-hl-show-hunk-inline.el (diff-hl-show-hunk-inline): Update footer text to
include Ediff keybinding.

* diff-hl-show-hunk-posframe.el (diff-hl-show-hunk-posframe--header-line): Add
Ediff button to the posframe header line.