### PR TITLE
Add customizable inline hunk faces

### DIFF
--- a/diff-hl-show-hunk-inline.el
+++ b/diff-hl-show-hunk-inline.el
@@ -74,6 +74,24 @@ the hunk consist only on added lines, then
 `diff-hl-show-hunk--no-lines-removed-message' it is shown."
   :type 'boolean)
 
+(defface diff-hl-show-hunk-inline-base
+  '((((class color) (min-colors 88) (background light))
+     :foreground "black" :background "gray88" :extend t)
+    (((class color) (min-colors 88) (background dark))
+     :foreground "white" :background "#gray13" :extend t))
+  "Face used for background of shown hunk."
+  :group 'diff-hl-show-hunk-inline)
+
+(defface diff-hl-show-hunk-inline-ul
+  '((((class color) (min-colors 88))
+     :inherit diff-hl-show-hunk-inline-base :underline t))
+  "Face used for background of shown hunk with underline.")
+
+(defface diff-hl-show-hunk-inline-ol
+  '((((class color) (min-colors 88))
+     :inherit diff-hl-show-hunk-inline-base :overline t))
+  "Face used for background of shown hunk with overline.")
+
 (defun diff-hl-show-hunk-inline--splice (list offset length)
   "Compute a sublist of LIST starting at OFFSET, of LENGTH."
   (butlast
@@ -115,7 +133,7 @@ Compute it from some WIDTH, and some optional HEADER text."
          (new-width (- width (length header) (length scroll-indicator)))
          (line (propertize (concat (diff-hl-show-hunk-inline--separator new-width)
                                    header scroll-indicator )
-                           'face '(:underline t))))
+                           'face 'diff-hl-show-hunk-inline-ul)))
     (concat line "\n") ))
 
 (defun diff-hl-show-hunk-inline--compute-footer (width &optional footer)
@@ -136,7 +154,7 @@ Compute it from some WIDTH, and some optional FOOTER text."
                                                 'face '(:underline t)))))
          (line (propertize (concat (diff-hl-show-hunk-inline--separator new-width)
                                    footer scroll-indicator)
-                           'face '(:overline t))))
+                           'face 'diff-hl-show-hunk-inline-ol)))
     (concat blank-line "\n" line)))
 
 (defun diff-hl-show-hunk-inline--separator (width &optional sep)

--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -61,6 +61,14 @@ corresponding to the clicked line in the original buffer."
           (const :tag "Show inline" diff-hl-show-hunk-inline)
           (const :tag "Show using posframe" diff-hl-show-hunk-posframe)))
 
+(defface diff-hl-show-hunk-bg
+  '((((class color) (min-colors 88) (background light))
+     :background "old lace" :extend t)
+    (((class color) (min-colors 88) (background dark))
+     :background "#555533" :extend t))
+  "Face used for background of shown hunk."
+  :group 'diff-hl-show-hunk)
+
 (defvar diff-hl-show-hunk-mouse-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<left-margin> <mouse-1>") 'diff-hl-show-hunk--click)
@@ -212,7 +220,9 @@ Returns a list with the buffer and the line number of the clicked line."
   (interactive "e")
   ;; Go the click's position.
   (posn-set-point (event-start event))
-  (diff-hl-show-hunk))
+  (if (and diff-hl-show-hunk--original-window (window-live-p diff-hl-show-hunk--original-window))
+      (diff-hl-show-hunk-hide)
+    (diff-hl-show-hunk)))
 
 (defvar diff-hl-show-hunk-map
   (let ((map (make-sparse-keymap)))
@@ -317,6 +327,7 @@ The backend is determined by `diff-hl-show-hunk-function'."
             (end (overlay-end overlay))
             (type (overlay-get overlay 'diff-hl-hunk-type)))
         (setq diff-hl-show-hunk--original-overlay (make-overlay start end))
+        (overlay-put diff-hl-show-hunk--original-overlay 'face 'diff-hl-show-hunk-bg)
         (overlay-put diff-hl-show-hunk--original-overlay 'diff-hl-hunk-type type)))
 
     (unless overlay


### PR DESCRIPTION
Add two cusomizable faces (four in total)

  - diff-hl-show-hunk-bg Background color for changed region when hunk is shown. This face is used for creating an overlay that tints the background for the current lines of the changed region in the buffer when viewing the hunk.

  - diff-hl-show-hunk-inline-base Foreground and background colors for the header and footer when viewing a hunk.

  - diff-hl-show-hunk-inline-ul Inherits from diff-hl-show-hunk-inline-base and adds an underline to the face.

  - diff-hl-show-hunk-inline-ol Inherits from diff-hl-show-hunk-inline-base and adds an overline to the face.

Modifies diff-hl-show-hunk--click function so mouse clicks toggles showing the hunk on and off.