### PR TITLE
Fix: diff-hl-magit-post-refresh wrong file name

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1437,7 +1437,7 @@ The value of this variable is a mode line template as in
                    (backend (vc-backend file)))
               (when backend
                 (cond
-                 ((member (file-name-nondirectory file) modified-files)
+                 ((member (file-relative-name file topdir) modified-files)
                   (when (memq (vc-state file) unmodified-states)
                     (vc-state-refresh file backend))
                   (diff-hl-update))

--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1437,7 +1437,7 @@ The value of this variable is a mode line template as in
                    (backend (vc-backend file)))
               (when backend
                 (cond
-                 ((member file modified-files)
+                 ((member (file-name-nondirectory file) modified-files)
                   (when (memq (vc-state file) unmodified-states)
                     (vc-state-refresh file backend))
                   (diff-hl-update))


### PR DESCRIPTION
`git diff-tree` is used and generates relative (to top level) file names. 
`buffer-file-name` generates full paths. 

The following condition always fails due to the file names being different:

https://github.com/dgutov/diff-hl/blob/7d873b2f58908de1ea2f499da9bf993e088953d7/diff-hl.el#L1440

This fixes the refresh related to magit actions.