### PR TITLE
Fix async diff buffer race causing wrong/missing highlights and errors

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -502,7 +502,12 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
          ((and
            (not diff-hl-highlight-reference-function)
            (diff-hl-modified-p state))
-          `((:working . ,(diff-hl-changes-buffer file backend))))
+          ;; Use fresh, unique buffers: with async updates several can be
+          ;; in flight at once, and a shared buffer name would let them
+          ;; clobber each other's output (or get killed mid-flight).
+          `((:working . ,(diff-hl-changes-buffer
+                          file backend nil
+                          (generate-new-buffer-name " *diff-hl* ")))))
          ((or
            diff-hl-reference-revision
            (diff-hl-modified-p state))
@@ -513,9 +518,12 @@ It can be a relative expression as well, such as \"HEAD^\" with Git, or
                                                (if hide-staged
                                                    'git-index
                                                  (diff-hl-head-revision backend))
-                                               " *diff-hl-reference* ")))
+                                               (generate-new-buffer-name
+                                                " *diff-hl-reference* "))))
                  (diff-hl-reference-revision nil)
-                 (work-changes (diff-hl-changes-buffer file backend)))
+                 (work-changes (diff-hl-changes-buffer
+                                file backend nil
+                                (generate-new-buffer-name " *diff-hl* "))))
             `((:reference . ,ref-changes)
               (:working . ,work-changes))))
          ((eq state 'added)
@@ -743,14 +751,29 @@ Return a list of line overlays used."
               (when (not (or changes ref-changes))
                 (diff-hl--autohide-margin))))))))))
 
+(defun diff-hl--with-resolved-buffer (cb)
+  "Parse the diff in the current buffer, pass the changes to CB, then kill it.
+The buffer is created per-update by `diff-hl-changes', so we own it."
+  (let ((buf (current-buffer)))
+    (unwind-protect
+        (funcall cb (diff-hl-changes-from-buffer buf))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
 (defun diff-hl--resolve (value-or-buffer cb)
   (if (listp value-or-buffer)
       (funcall cb value-or-buffer)
+    ;; VALUE-OR-BUFFER is a fresh per-update diff buffer.  It can still be
+    ;; killed out from under us (e.g. the visited buffer is closed
+    ;; mid-update), so guard the access; and since it's ours, kill it when
+    ;; we're done parsing it.
     (static-if (fboundp 'vc-run-delayed-success)
         ;; Emacs 31.
-        (with-current-buffer value-or-buffer
-          (vc-run-delayed-success 1
-            (funcall cb (diff-hl-changes-from-buffer (current-buffer)))))
+        (if (buffer-live-p (get-buffer value-or-buffer))
+            (with-current-buffer value-or-buffer
+              (vc-run-delayed-success 1
+                (diff-hl--with-resolved-buffer cb)))
+          (funcall cb nil))
       (diff-hl--when-done value-or-buffer
                           #'diff-hl-changes-from-buffer
                           cb))))
@@ -762,11 +785,21 @@ Return a list of line overlays used."
      ((or (null proc) (eq (process-status proc) 'exit))
       ;; Make sure we've read the process's output before going further.
       (when proc (accept-process-output proc))
+      (if (buffer-live-p (get-buffer buffer))
+          ;; The buffer is ours (created per-update): parse it, then kill it.
+          (unwind-protect
+              (with-current-buffer buffer
+                (funcall callback (funcall get-value buffer)))
+            (when (get-buffer buffer)
+              (kill-buffer buffer)))
+        ;; It was killed out from under us; keep the chain going.
+        (funcall callback nil)))
+     ;; If the process was deleted, give up but keep the chain going, so
+     ;; the rest of the update (and any sibling buffer's cleanup) proceeds.
+     ((eq (process-status proc) 'signal)
       (when (get-buffer buffer)
-        (with-current-buffer buffer
-          (funcall callback (funcall get-value buffer)))))
-     ;; If process was deleted, we ignore it.
-     ((eq (process-status proc) 'signal))
+        (kill-buffer buffer))
+      (funcall callback nil))
      ;; If a process is running, set the sentinel.
      ((eq (process-status proc) 'run)
       (add-function

--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -140,10 +140,15 @@
      (diff-hl-mode 1)
      (diff-hl-update)
 
-     (while (or (process-live-p
-                  (get-buffer-process " *diff-hl* "))
-                (process-live-p
-                  (get-buffer-process " *diff-hl-reference* ")))
+     ;; Diff buffers now have unique, generated names, so wait for any
+     ;; still-running diff-hl process instead of fixed buffer names.
+     (while (let (running)
+              (dolist (p (process-list))
+                (let ((b (process-buffer p)))
+                  (when (and (buffer-live-p b)
+                             (string-prefix-p " *diff-hl" (buffer-name b)))
+                    (setq running t))))
+              running)
        (accept-process-output nil 0.05))
 
      (diff-hl-previous-hunk)


### PR DESCRIPTION
I've been getting recurring errors with `diff-hl` for years and I'm hoping this fixes it:

```elisp
Debugger entered--Lisp error: (error "No buffer named  *diff-hl-reference* ")
  diff-hl--resolve(" *diff-hl-reference* " #f(compiled-function (ref-changes) #<bytecode -0x15e845b644d57d3>))
  #f(compiled-function (changes) #<bytecode 0xa558579df63854e>)(((19 1 1 change) (37 14 0 insert)))
  #f(compiled-function () #<bytecode 0x13c70aa882a85abb>)()
  #f(compiled-function () #<bytecode -0x1cd22bda0b376558>)()
  #f(compiled-function (proc msg) #<bytecode -0x17dde961f272a0e7>)(#<process Diff> "exited abnormally with code 1\n")
  apply(#f(compiled-function (proc msg) #<bytecode -0x17dde961f272a0e7>) (#<process Diff> "exited abnormally with code 1\n"))
  #f(advice #f(compiled-function (proc msg) #<bytecode -0x17dde961f272a0e7>) :after #f(compiled-function (proc msg) #<bytecode 0x81d02bf837bf743>))(#<process Diff> "exited abnormally with code 1\n")
  #<subr completing-read-default>("[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil)
  apply((#<subr completing-read-default> "[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil))
  #f(compiled-function (&rest app) #<bytecode 0x1a4535676121e62d>)(#<subr completing-read-default> "[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil)
  apply(#f(compiled-function (&rest app) #<bytecode 0x1a4535676121e62d>) (#<subr completing-read-default> "[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil))
  vertico--advice(#<subr completing-read-default> "[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil)
  apply(vertico--advice #<subr completing-read-default> ("[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil))
  completing-read-default("[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil nil nil nil)
  completing-read("[magit-gptcommit] Find file: " #f(compiled-function (string pred action) #<bytecode -0x8be503018da454c>) nil nil nil)
  projectile-completing-read("Find file: " ("LICENSE" "README.md" "magit-gptcommit.el") :caller projectile-read-file)
  projectile--find-file(nil)
  projectile-find-file(nil)
  funcall-interactively(projectile-find-file nil)
  call-interactively(projectile-find-file)
  (cond ((and projectile-project-root (file-equal-p projectile-project-root default-directory)) (if (doom-project-p default-directory) nil (setq projectile-enable-caching nil)) (call-interactively (if (doom-module-active-p :completion 'ivy) #'counsel-projectile-find-file #'projectile-find-file))) ((and (and (boundp 'ivy-mode) ivy-mode) (fboundp 'counsel-file-jump)) (call-interactively #'counsel-file-jump)) ((and (and (boundp 'helm-mode) helm-mode) (fboundp 'helm-find-files)) (call-interactively #'helm-find-files)) ((let* ((project-current-directory-override (and t dir)) (pr (and project-current-directory-override (project-current t dir)))) (if pr (condition-case _ (project-find-file-in nil (list dir) pr t) (wrong-type-argument (call-interactively #'find-file)))))) ((call-interactively #'find-file)))
  (let* ((default-directory (file-truename dir)) (projectile-project-root (doom-project-root dir)) (projectile-enable-caching projectile-enable-caching)) (cond ((and projectile-project-root (file-equal-p projectile-project-root default-directory)) (if (doom-project-p default-directory) nil (setq projectile-enable-caching nil)) (call-interactively (if (doom-module-active-p :completion 'ivy) #'counsel-projectile-find-file #'projectile-find-file))) ((and (and (boundp 'ivy-mode) ivy-mode) (fboundp 'counsel-file-jump)) (call-interactively #'counsel-file-jump)) ((and (and (boundp 'helm-mode) helm-mode) (fboundp 'helm-find-files)) (call-interactively #'helm-find-files)) ((let* ((project-current-directory-override (and t dir)) (pr (and project-current-directory-override (project-current t dir)))) (if pr (condition-case _ (project-find-file-in nil (list dir) pr t) (wrong-type-argument (call-interactively ...)))))) ((call-interactively #'find-file))))
  doom-project-find-file("/home/st/src/magit-gptcommit/")
  funcall(doom-project-find-file "/home/st/src/magit-gptcommit/")
  (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot))
  (let* ((ws-param '+workspace-project) (ws (+workspace-get pname t)) (ws (if (and ws (condition-case nil (progn (file-equal-p ... proot)) (error nil))) ws (let* ((parts (nreverse ...)) (pre (cdr parts)) (post (list ...))) (while (and pre (setq ws ...) (not ...)) (setq post (cons ... post))) (if pre nil ws)))) (ws (or ws (+workspace-get pname t) (+workspace-new pname)))) (set-persp-parameter ws-param proot ws) (+workspace-switch pname) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)) (+workspace-message (format "Switched to '%s' in new workspace" pname) 'success))
  (if (and (not (null +workspaces-on-switch-project-behavior)) (or (eq +workspaces-on-switch-project-behavior t) (+workspace--protected-p (safe-persp-name (get-current-persp))) (+workspace-buffer-list))) (let* ((ws-param '+workspace-project) (ws (+workspace-get pname t)) (ws (if (and ws (condition-case nil (progn ...) (error nil))) ws (let* ((parts ...) (pre ...) (post ...)) (while (and pre ... ...) (setq post ...)) (if pre nil ws)))) (ws (or ws (+workspace-get pname t) (+workspace-new pname)))) (set-persp-parameter ws-param proot ws) (+workspace-switch pname) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)) (+workspace-message (format "Switched to '%s' in new workspace" pname) 'success)) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer) (message "Switched to '%s'" pname)) (condition-case err (+workspace-rename (+workspace-current-name) pname) ((debug error) (message "Workspace error: %s" err) nil)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)))
  (progn (if (and (not (null +workspaces-on-switch-project-behavior)) (or (eq +workspaces-on-switch-project-behavior t) (+workspace--protected-p (safe-persp-name (get-current-persp))) (+workspace-buffer-list))) (let* ((ws-param '+workspace-project) (ws (+workspace-get pname t)) (ws (if (and ws (condition-case nil ... ...)) ws (let* (... ... ...) (while ... ...) (if pre nil ws)))) (ws (or ws (+workspace-get pname t) (+workspace-new pname)))) (set-persp-parameter ws-param proot ws) (+workspace-switch pname) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)) (+workspace-message (format "Switched to '%s' in new workspace" pname) 'success)) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer) (message "Switched to '%s'" pname)) (condition-case err (+workspace-rename (+workspace-current-name) pname) ((debug error) (message "Workspace error: %s" err) nil)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot))))
  (if persp-mode (progn (if (and (not (null +workspaces-on-switch-project-behavior)) (or (eq +workspaces-on-switch-project-behavior t) (+workspace--protected-p (safe-persp-name (get-current-persp))) (+workspace-buffer-list))) (let* ((ws-param '+workspace-project) (ws (+workspace-get pname t)) (ws (if (and ws ...) ws (let* ... ... ...))) (ws (or ws (+workspace-get pname t) (+workspace-new pname)))) (set-persp-parameter ws-param proot ws) (+workspace-switch pname) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable ...))) (hack-dir-local-variables-non-file-buffer)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)) (+workspace-message (format "Switched to '%s' in new workspace" pname) 'success)) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable 'default-directory))) (hack-dir-local-variables-non-file-buffer) (message "Switched to '%s'" pname)) (condition-case err (+workspace-rename (+workspace-current-name) pname) ((debug error) (message "Workspace error: %s" err) nil)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)))))
  (let* ((default-directory (or dir default-directory)) (pname (doom-project-name)) (proot (file-truename default-directory)) projectile-project-root) (if persp-mode (progn (if (and (not (null +workspaces-on-switch-project-behavior)) (or (eq +workspaces-on-switch-project-behavior t) (+workspace--protected-p (safe-persp-name ...)) (+workspace-buffer-list))) (let* ((ws-param '+workspace-project) (ws (+workspace-get pname t)) (ws (if ... ws ...)) (ws (or ws ... ...))) (set-persp-parameter ws-param proot ws) (+workspace-switch pname) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot ...)) (hack-dir-local-variables-non-file-buffer)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot)) (+workspace-message (format "Switched to '%s' in new workspace" pname) 'success)) (save-current-buffer (set-buffer (doom-fallback-buffer)) (setq default-directory (prog1 proot (make-local-variable ...))) (hack-dir-local-variables-non-file-buffer) (message "Switched to '%s'" pname)) (condition-case err (+workspace-rename (+workspace-current-name) pname) ((debug error) (message "Workspace error: %s" err) nil)) (if current-prefix-arg nil (funcall +workspaces-switch-project-function proot))))))
  +workspaces-switch-to-project-h()
  projectile-switch-project-by-name("~/src/magit-gptcommit/" nil)
  #f(compiled-function (project) #<bytecode 0x4c89b65f2a01916>)("~/src/magit-gptcommit/")
  projectile-completing-read("Switch to project: " ("~/src/magit-gptcommit/" "~/.config/emacs/" "~/src/ghostel/" "~/src/embark/" "~/.config/doom/secrets/" "~/src/doomemacs/" "~/" "/etc/portage/" "~/.emacs.d/" "~/.config/temple-emacs/" "~/src/temple-os-emacs-theme/" "~/org/" "~/src/hasktorch-first/" "~/src/cyber-angel-emacs-elisp-trash/" "~/src/evil-easymotion/" "~/src/lsp-treemacs/" "~/src/emacs/" "~/src/oasis-poker-helper/" "~/src/topos/" "~/src/roulette-calculator/" "~/src/portage/" "~/src/kitty-graphics.el/" "~/src/dotfiles/" "~/src/casino-tracker-service/" "~/src/casino-tracker/" "~/src/buddy/" "~/src/alert/") :action #f(compiled-function (project) #<bytecode 0x4c89b65f2a01916>) :caller projectile-read-project)
  projectile-switch-project(nil)
  funcall-interactively(projectile-switch-project nil)
  command-execute(projectile-switch-project)
```