### PR TITLE
Fix cl-assertion-failed in diff-hl-revert-hunk caused by track-changes

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1037,12 +1037,15 @@ that file, if it's present."
           (progn
             (vc-setup-buffer diff-buffer)
             (with-current-buffer buffer
-              ;; Ensure that the buffer-local variable value is applied.
               (diff-hl-diff-against-reference file backend diff-buffer))
-            (diff-mode)
-            (setq-local diff-vc-backend backend)
-            (setq-local diff-vc-revisions (list diff-hl-reference-revision nil))
-            (setq buffer-read-only t)
+            (with-current-buffer diff-buffer
+              ;; Prevent diff-mode from registering track-changes for this
+              ;; temporary buffer
+              (cl-letf (((symbol-function 'track-changes-register) #'ignore))
+                (diff-mode))
+              (setq-local diff-vc-backend backend)
+              (setq-local diff-vc-revisions (list diff-hl-reference-revision nil))
+              (setq buffer-read-only t))
             (pop-to-buffer diff-buffer)
             (vc-run-delayed
               (vc-diff-finish diff-buffer nil)


### PR DESCRIPTION
This pull request fixes #286

It disables track-changes-mode inside the temporary *diff-hl-revert* buffer. This prevents asynchronous background timers from firing while execution is suspended at the yes-or-no-p prompt.

Because the buffer is narrowed to highlight the hunk, the tracker previously attempted to access coordinates outside the visible region, causing an assertion failure.

