### PR TITLE
diff-hl-show-hunk-inline: Put underline at descent line

### DIFF
--- a/diff-hl-show-hunk-inline.el
+++ b/diff-hl-show-hunk-inline.el
@@ -105,6 +105,10 @@ Compute it from LINES starting at INDEX with a WINDOW-SIZE."
          (index (min index (- len window-size))))
     (diff-hl-show-hunk-inline--splice lines index window-size)))
 
+(defun diff-hl-show-hunk-inline--underline-face ()
+  "Return the face used for inline popup underlines."
+  `(:underline ,(if (>= emacs-major-version 29) '(:position t) t)))
+
 (defun diff-hl-show-hunk-inline--compute-header (width &optional header)
   "Compute the header of the popup.
 Compute it from some WIDTH, and some optional HEADER text."
@@ -115,7 +119,7 @@ Compute it from some WIDTH, and some optional HEADER text."
          (new-width (- width (length header) (length scroll-indicator)))
          (line (propertize (concat (diff-hl-show-hunk-inline--separator new-width)
                                    header scroll-indicator )
-                           'face '(:underline t))))
+                           'face (diff-hl-show-hunk-inline--underline-face))))
     (concat line "\n") ))
 
 (defun diff-hl-show-hunk-inline--compute-footer (width &optional footer)
@@ -133,7 +137,7 @@ Compute it from some WIDTH, and some optional FOOTER text."
          (blank-line (if (display-graphic-p)
                          ""
                        (concat "\n" (propertize (diff-hl-show-hunk-inline--separator width)
-                                                'face '(:underline t)))))
+                                                'face (diff-hl-show-hunk-inline--underline-face)))))
          (line (propertize (concat (diff-hl-show-hunk-inline--separator new-width)
                                    footer scroll-indicator)
                            'face '(:overline t))))


### PR DESCRIPTION
Currently the inline popups display the top border (drawn using `:underline` on the header line) slightly too high. This is because Emacs draws underlines at the baseline unless `x-underline-at-descent-line` is enabled, but that setting affects Emacs globally. Since Emacs 29, the `:underline` attribute accepts the property `:position`, which specifies where the underline should be drawn. If it is non-nil, then the underline is displayed at the descent of the text instead of the baseline. I've made a tiny change to enable that property for underlines in diff-hl when Emacs 29+ is detected. I've included two screenshots below showing the difference. Notice that the bottom border is unaffected, because it's an overline.

**Before:**

<img width="2559" height="1599" alt="Screenshot From 2026-06-21 16-02-00" src="https://github.com/user-attachments/assets/90edc8c1-32b1-4c3f-8f25-969e908ed922" />

**After:**

<img width="2559" height="1599" alt="Screenshot From 2026-06-21 16-01-11" src="https://github.com/user-attachments/assets/897a7806-80e4-4d25-b650-e8ec13facb52" />