### PR TITLE
Bug: Add missing nil argument to vc-jj--process-lines call

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1582,7 +1582,8 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
       (goto-char (point-min))
       (buffer-substring-no-properties (point) (line-end-position))))
    ((eq backend 'JJ)
-    (car (last (vc-jj--process-lines "log" "--no-graph"
+    (car (last (vc-jj--process-lines nil
+                                     "log" "--no-graph"
                                      "-r" revision
                                      "-T" "change_id" "-n" "1"))))
    (t


### PR DESCRIPTION
Before this change, the first argument to `vc-jj--process-lines` was `"log"`. This seems wrong.

The signature of the function is: `(defun vc-jj--process-lines (file-or-list &rest args))`

The docstring says:

> FILE-OR-LIST may be nil or non-nil.  When non-nil, it should be a file or a list of files.

"log" clearly is not a file or list of files. It's the jj subcommand we aim to run.

Running the following in my repository:

`(vc-jj--process-lines "log" "--no-graph" "-r" "@-" "-T" "change_id" "-n" "1")` returns `nil`

...whereas running the following:

`(vc-jj--process-lines nil "log" "--no-graph" "-r" "@-" "-T" "change_id" "-n" "1")` returns the actual revision