### PR TITLE
Use jj `commit_id`, not `change_id`, as the reference revision

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -1640,7 +1640,7 @@ CONTEXT-LINES is the size of the unified diff context, defaults to 0."
     (car (last (vc-jj--process-lines nil
                                      "log" "--no-graph"
                                      "-r" revision
-                                     "-T" "change_id" "-n" "1"))))
+                                     "-T" "commit_id" "-n" "1"))))
    (t
     revision)))
 


### PR DESCRIPTION
`diff-hl-create-revision` caches the reference file in a temp file keyed by the revision string, assuming that string is content-addressed, and only refetches when it's missing. A jj change ID survives changes to the contents. So after (for example) squashing into `@-`, the fringe keeps showing the squashed lines as uncommitted. `commit_id` changes with the content and fixes it.

Related: 6938d20 / #250 