### PR TITLE
disable `vc-dir-process-output-limit` for diff-hl-dired

### DIFF
--- a/diff-hl-dired.el
+++ b/diff-hl-dired.el
@@ -36,6 +36,7 @@
 (require 'vc-hooks)
 
 (defvar diff-hl-dired-process-buffer nil)
+(defvar vc-dir-process-output-limit)
 
 (defgroup diff-hl-dired nil
   "VC diff highlighting on the side of a Dired window."
@@ -104,6 +105,9 @@ status indicators."
               (generate-new-buffer " *diff-hl-dired* tmp status")))
       (with-current-buffer diff-hl-dired-process-buffer
         (setq default-directory (expand-file-name def-dir))
+        ;; This isn't a VC-Dir buffer, so VC-Dir's truncation UI
+        ;; cannot be used here.
+        (setq-local vc-dir-process-output-limit nil)
         (erase-buffer)
         (diff-hl-dired-status-files
          backend def-dir


### PR DESCRIPTION
Recent upstream Emacs change ([268e055e051 (“Limit VC-Dir status process output processing”)](https://cgit.git.savannah.gnu.org/cgit/emacs.git/commit/?id=268e055e0515ccec8159b13d4b2e97428bd63b5e)) introduced `vc-dir-process-output-limit` variable with default value of 3000 characters & changed VC backend `dir-status-files` implementations to call `vc-dir-maybe-narrow-and-show-more-button` before processing larger output.

Basically if there are changes in excess of limit, emacs truncates the result and adds a button to rerun the refresh without a limit, introducing dependency on status process buffer’s `vc-parent-buffer`, pointing to the VC-Dir buffer, which is not present when diff-hl ends up calling that code. 

This breaks diff-hl in dired, producing an error like this:
```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  vc-dir-maybe-narrow-and-show-more-button("(reported states may be incorrect)")
  #f(compiled-function () #<bytecode -0x1355c4af29e0d36f>)()
  #f(compiled-function () #<bytecode 0xe6ea5554b3be332>)()
  #f(compiled-function (proc msg) #<bytecode 0x6d883a17e9c9bdb>)(#<process git> "finished\n")
  apply(#f(compiled-function (proc msg) #<bytecode 0x6d883a17e9c9bdb>) (#<process git> "finished\n"))
  #f(advice #f(compiled-function (proc msg) #<bytecode 0x6d883a17e9c9bdb>) :after #f(advice #f(compiled-function (proc msg) #<bytecode 0x6d883a17e9c9bdb>) :after ignore))(#<process git> "finished\n")
```

Proposed change is to not have that output limit in diff-hl’s private status buffer. 