### PR TITLE
Handle unborn Git branches when staged changes are hidden.

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -476,16 +476,18 @@ BUFFER defaults to the current buffer."
            "diff-files"
            (cons "-p" (vc-switches 'git 'diff))))
    ((eq new-rev 'git-index)
+    ;; With no revision, `git diff --cached' uses HEAD when it exists and
+    ;; the empty tree on an unborn branch.
     (apply #'vc-git-command buffer
            (if (diff-hl--use-async-p) 'async 1)
            (list file)
-           "diff-index"
+           "diff"
            (append
             (vc-switches 'git 'diff)
-            (list "-p" "--cached"
-                  (or diff-hl-reference-revision
-                      (diff-hl-head-revision backend))
-                  "--"))))
+            (list "-p" "--cached")
+            (when diff-hl-reference-revision
+              (list diff-hl-reference-revision))
+            (list "--"))))
    (t
     (condition-case err
         (vc-call-backend backend 'diff (list file)

--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -168,12 +168,14 @@
       (should
        (null
         (assoc-default :reference (diff-hl-changes)))))
-    (let* ((diff-hl-show-staged-changes nil)
-           (res-buf (assoc-default :reference (diff-hl-changes))))
-      (should
-       (equal
-        (diff-hl-changes-from-buffer res-buf)
-        '((1 1 0 insert)))))))
+    (dolist (reference '(nil "HEAD"))
+      (let* ((diff-hl-reference-revision reference)
+             (diff-hl-show-staged-changes nil)
+             (res-buf (assoc-default :reference (diff-hl-changes))))
+        (should
+         (equal
+          (diff-hl-changes-from-buffer res-buf)
+          '((1 1 0 insert))))))))
 
 (diff-hl-deftest diff-hl-flydiff-can-ignore-staged-changes ()
   (diff-hl-test-in-source
@@ -194,6 +196,41 @@
        (equal (diff-hl-changes-from-buffer
                (diff-hl-diff-buffer-with-reference (diff-hl--buffer-file-name)))
               '((12 1 0 insert)))))))
+
+(ert-deftest diff-hl-can-ignore-staged-changes-in-unborn-repository ()
+  (let* ((directory (make-temp-file "diff-hl-unborn-" t))
+         (default-directory directory)
+         (file (expand-file-name "tracked" directory))
+         buffer)
+    (unwind-protect
+        (progn
+          (vc-git-command nil 0 nil "init")
+          (with-temp-file file
+            (insert "staged\n"))
+          (vc-git-command nil 0 file "add")
+          (with-temp-file file
+            (insert "staged\nworking\n"))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (dolist (async '(t nil))
+              (let* ((diff-hl-highlight-reference-function #'ignore)
+                     (diff-hl-show-staged-changes nil)
+                     (diff-hl-update-async async)
+                     (changes (diff-hl-changes))
+                     (reference (assoc-default :reference changes))
+                     (working (assoc-default :working changes)))
+                (while (or (process-live-p (get-buffer-process reference))
+                           (process-live-p (get-buffer-process working)))
+                  (accept-process-output nil 0.05))
+                (should (equal (diff-hl-changes-from-buffer reference)
+                               '((1 1 0 insert))))
+                (should (equal (diff-hl-changes-from-buffer working)
+                               '((2 1 0 insert))))))))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer))
+      (delete-directory directory t))))
 
 (diff-hl-deftest diff-hl-can-split-away-no-trailing-newline ()
   (diff-hl-test-in-source


### PR DESCRIPTION
Fixes #298 

When `diff-hl-show-staged-changes` is nil, diff-hl currently
computes the staged/reference layer with:

    git diff-index --cached HEAD

This fails in a repository with an unborn branch because `HEAD`
does not exist yet. Synchronous updates signal status 128.
Asynchronous updates subsequently pass Git's fatal diagnostic to
`diff-hl-changes-from-buffer`, which fails in
`diff-beginning-of-hunk`.

Use `git diff --cached [<commit>]` instead. When no explicit commit
is supplied, Git compares the index against `HEAD` when it exists
and against the empty tree on an unborn branch. An explicit
`diff-hl-reference-revision` is still passed through unchanged.

The regression test creates a temporary unborn repository with
separate staged and worktree changes and verifies both layers with
synchronous and asynchronous updates. The existing test also
checks implicit and explicit `HEAD` references.

Tested with Emacs 30.2:

- staged-change tests: 3/3 passed
- remaining applicable ERT tests: 15/15 passed
- byte compilation with warnings as errors passed
- `git diff --check` passed