### PR TITLE
Make diff-hl-timer buffer-local

### DIFF
--- a/diff-hl.el
+++ b/diff-hl.el
@@ -638,7 +638,7 @@ contents as they are (or would be) after applying the changes in NEW."
         (run-hook-with-args-until-success 'diff-hl-async-inhibit-functions
                                           default-directory))))
 
-(defvar diff-hl-timer nil)
+(defvar-local diff-hl-timer nil)
 
 (defun diff-hl-update ()
   "Updates the diff-hl overlay."

--- a/test/diff-hl-test.el
+++ b/test/diff-hl-test.el
@@ -79,6 +79,15 @@
        (diff-hl-test-teardown))))
 (put 'diff-hl-deftest 'lisp-indent-function 'defun)
 
+(ert-deftest diff-hl-update-once-schedules-per-buffer ()
+  (let ((diff-hl-timer nil)
+        (calls 0))
+    (cl-letf (((symbol-function 'run-with-idle-timer)
+               (lambda (&rest _) (cl-incf calls))))
+      (with-temp-buffer (diff-hl-update-once))
+      (with-temp-buffer (diff-hl-update-once)))
+    (should (= calls 2))))
+
 (diff-hl-deftest diff-hl-insert ()
   (diff-hl-test-in-source
     (goto-char (point-max))


### PR DESCRIPTION
This PR makes `diff-hl-timer` buffer-local so a pending timer in one buffer does not prevent `diff-hl-update-once` from scheduling an update in another.

I discovered this while using `(setq diff-hl-update-async t)` and I noticed that newly opened buffers would not receive highlights until their first save.

I added a test that verifies that `diff-hl-update-once` schedules an independent timer for each buffer.